### PR TITLE
fix: distributed_strategy moved to init (no longer in config) as it is not json serializable

### DIFF
--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -4,7 +4,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Moved distributed_strategy to init of LLaMA as it is not necessary to be part of the config, and also is not json serializable. In a separate PR, plan to add a save to model which will save the model weights, config (as json since is a nice feature to have a human readable config), and use pickle to save the distributed_strategy all in a single directory.