### PR TITLE
Add model save and load

### DIFF
--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -4,7 +4,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -46,7 +46,6 @@ class LLaMAConfig(ModelConfig):
     activation_fn: str = "swish"
     p_dropout: float = 0.0
     max_expected_seq_len: int = 2048
-    distributed_strategy: DistributedStrategy = NoOpStrategy
 
 
 class LLaMABlock(nn.Module):
@@ -158,6 +157,7 @@ class LLaMA(nn.Module):
     def __init__(
         self,
         config: Optional[LLaMAConfig] = None,
+        distributed_strategy: DistributedStrategy = NoOpStrategy,
         **kwargs,
     ):
         super(LLaMA, self).__init__()
@@ -166,6 +166,7 @@ class LLaMA(nn.Module):
         else:
             self.config = LLaMAConfig()
         self.config.update_config(**kwargs)
+        self.distributed_strategy = distributed_strategy
 
         self.width = self.config.emb_dim
         self.pad_id = self.config.pad_id
@@ -180,7 +181,7 @@ class LLaMA(nn.Module):
             tie_weights=False,
             bias=False,
         )
-        self.shared = self.config.distributed_strategy.distribute_module(shared)
+        self.shared = self.distributed_strategy.distribute_module(shared)
 
         self.rot_emb = RotaryEmbedding(
             self.config.emb_dim // self.config.nheads,
@@ -190,7 +191,7 @@ class LLaMA(nn.Module):
         self.layers = []
         for i in range(self.config.nlayers):
             block = LLaMABlock(self.config, self.rot_emb)
-            block = self.config.distributed_strategy.distribute_layer(block, i)
+            block = self.distributed_strategy.distribute_layer(block, i)
             self.layers.append(block)
         self.layers = nn.ModuleList(self.layers)
 
@@ -218,9 +219,18 @@ class LLaMA(nn.Module):
     def reset_params(self):
         # Modules are self-initializing, we're just going to down-scale the final prediction head to be
         # mixed-fan (inputs and gradients scale to the same inverse factors) if it isn't tied
-        self.shared.head.weight.data.normal_(0, 1 / math.sqrt(math.sqrt(self.width * self.shared.vocab_size)))
+        self.shared.head.weight.data.normal_(
+            0, 1 / math.sqrt(math.sqrt(self.width * self.shared.vocab_size))
+        )
 
-    def _helper(self, x_in, mask=None, past_key_value_states=None, use_cache=False, attn_algorithm=None):
+    def _helper(
+        self,
+        x_in,
+        mask=None,
+        past_key_value_states=None,
+        use_cache=False,
+        attn_algorithm=None,
+    ):
         # Embed the given vocabulary indices using the given attention mask, with pre-/post-norm and dropout as specified
         # x_in: batch_size x seq_len
         # mask: batch_size x seq_len x seq_len

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -1,0 +1,91 @@
+import os.path
+import tempfile
+
+import pytest
+
+from fms.distributed.strategy import NotDistributed, NoOpStrategy
+from fms.models.llama import LLaMA
+
+
+@pytest.fixture
+def text_file_path(tmpdir):
+    f = open(f"{tmpdir}/file.txt", "w+")
+    f.write("some line")
+    f.close()
+    yield f"{tmpdir}/file.txt"
+
+
+@pytest.fixture(params=[NotDistributed, NoOpStrategy])
+def mock_llama2():
+    return LLaMA(
+        src_vocab_size=256,
+        emb_dim=16,
+        multiple_of=2,
+        nheads=2,
+        nlayers=2,
+        norm_eps=1e-05,
+        pad_id=0,
+    )
+
+
+@pytest.fixture
+def model_location(tmpdir, mock_llama2):
+    mock_llama2.save(f"{tmpdir}/saved_model")
+    yield f"{tmpdir}/saved_model"
+
+
+def _assert_all_model_files_exist(model_path):
+    assert os.path.exists(model_path)
+    assert os.path.exists(f"{model_path}/config.json") and os.path.isfile(
+        f"{model_path}/config.json"
+    )
+    assert os.path.exists(f"{model_path}/model_state.pth") and os.path.isfile(
+        f"{model_path}/model_state.pth"
+    )
+    assert os.path.exists(f"{model_path}/distributed_strategy.bin") and os.path.isfile(
+        f"{model_path}/distributed_strategy.bin"
+    )
+
+
+def test_save(mock_llama2):
+    with tempfile.TemporaryDirectory() as workdir:
+        mock_llama2.save(f"{workdir}/llama_model")
+        _assert_all_model_files_exist(f"{workdir}/llama_model")
+
+
+def test_save_dir_already_exists(mock_llama2):
+    with tempfile.TemporaryDirectory() as workdir:
+        os.mkdir(f"{workdir}/llama_model")
+        mock_llama2.save(f"{workdir}/llama_model")
+        _assert_all_model_files_exist(f"{workdir}/llama_model")
+
+
+def test_load(model_location, mock_llama2):
+    llama = LLaMA.load(model_location)
+    assert llama.get_config().as_dict() == mock_llama2.get_config().as_dict()
+
+    m1_sd = llama.state_dict()
+    m2_sd = mock_llama2.state_dict()
+    assert m1_sd.keys() == m2_sd.keys()
+    is_equal_weights = True
+    for k in m1_sd.keys():
+        if m1_sd[k].ne(m2_sd[k]).sum() > 0:
+            is_equal_weights = False
+            break
+    assert is_equal_weights
+    assert type(llama.distributed_strategy) == type(mock_llama2.distributed_strategy)
+
+
+def test_save_not_directory(mock_llama2, text_file_path):
+    with pytest.raises(NotADirectoryError):
+        mock_llama2.save(text_file_path)
+
+
+def test_load_file_not_found(tmpdir):
+    with pytest.raises(FileNotFoundError):
+        LLaMA.load(f"{tmpdir}/no_file")
+
+
+def test_load_not_directory(text_file_path):
+    with pytest.raises(NotADirectoryError):
+        LLaMA.load(text_file_path)


### PR DESCRIPTION
- Added a model save and load which will save the model config, weights, and distributed strategy into a directory
- Added simple tests for model save/load

Usage:

```python
model = LLaMA()
model.save("/path/to/model")
model_loaded = LLaMA.load("/path/to/model")
```

Note: This has a dependency on #17 