### PR TITLE
partial fix for mqa issue with llama 70b

### DIFF
--- a/examples/inference.py
+++ b/examples/inference.py
@@ -141,8 +141,8 @@ def infer(use_cache, do_sample):
 
 
 print("generating output", local_rank)
-do_sample = [True, False]
-use_cache = [True, False]  # True/False are identical with greedy iff `torch.use_deterministic_algorithms(True)`
+do_sample = [False]
+use_cache = [False]  # True/False are identical with greedy iff `torch.use_deterministic_algorithms(True)`
 for sample, cache in itertools.product(do_sample, use_cache):
     infer(cache, sample)
 

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -75,6 +75,7 @@ class LLaMABlock(nn.Module):
         if self.config.kvheads == 0:
             kvheads = self.config.nheads
         else:
+            kvheads = self.config.kvheads
             assert self.config.nheads % self.config.kvheads == 0
 
         self.attn = MultiHeadAttention(


### PR DESCRIPTION
one line fix for reading of kvheads. Wasn't caught in initial testing because only llama 70b uses mqa.

There remains an issue with use_cache=True in llama 70b that will require more debugging, but this fix at least enables the use_cache=False case.
