### PR TITLE
fix a minor bug introduced by the last PR

### DIFF
--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -193,6 +193,9 @@ class MultiHeadAttention(nn.Module):
         if expansion != 1:
             keys_e = keys.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
             values_e = values.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
+        else:
+            keys_e = keys
+            values_e = values
 
         if attn_algorithm:
             # Pick which fused attn kernels will run.


### PR DESCRIPTION
After https://github.com/ibm-pytorch/foundation-model-stack/pull/21

I get a:
```
File “/home/bvaughan/miniconda3/envs/latest/lib/python3.11/site-packages/fms-0.0.1-py3.11.egg/fms/modules/attention.py”, line 209, in forward
                                                         keys_e,                                                                                                                                                                                             ^^^^^^                                                                                                                                                                                          UnboundLocalError: cannot access local variable ‘keys_e’ where it is not associated with a value
```

we should probably refactor this to make the cached and used key/value clearer but for now let's make sure main works.

