### PR TITLE
fix: config update_config now is renamed to updated and will perform a deep copy

### DIFF
--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import math
 import os
@@ -168,7 +169,7 @@ class LLaMA(nn.Module):
             self.config = config
         else:
             self.config = LLaMAConfig()
-        self.config.update_config(**kwargs)
+        self.config = self.config.updated(**kwargs)
         self.distributed_strategy = distributed_strategy
 
         self.width = self.config.emb_dim

--- a/fms/utils/config.py
+++ b/fms/utils/config.py
@@ -1,8 +1,11 @@
+import copy
 import inspect
 import json
 import os
 from dataclasses import asdict, dataclass
 from typing import Union
+
+from fm_nlp.architecture.config import ModelConfig
 
 
 @dataclass
@@ -28,9 +31,26 @@ class ModelConfig:
         with open(file_path, "w") as f:
             json.dump(self.as_dict(), f)
 
-    def update_config(self, **kwargs):
+    def updated(self, **kwargs) -> "ModelConfig":
+        """Clone this ModelConfig and override the parameters of the ModelConfig specified by kwargs
+
+        Note: This will always return a deep copy
+
+        Parameters
+        ----------
+        kwargs
+            all possibly ModelConfig dataclass named parameters to override
+
+        Returns
+        -------
+        ModelConfig
+            a new instance of ModelConfig with the parameters overridden
+        """
+        # create a deep copy as we don't want to modify this reference
+        copied_config = copy.deepcopy(self)
         for k, v in kwargs.items():
-            if hasattr(self, k):
-                setattr(self, k, v)
+            if hasattr(copied_config, k):
+                setattr(copied_config, k, v)
             else:
                 print(f"Warning: unknown parameter {k}")
+        return copied_config

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -1,0 +1,51 @@
+import pytest
+
+from fms.models.llama import LLaMA, LLaMAConfig
+
+
+def test_config_params_passed_as_kwargs_to_model():
+    params = {
+        "src_vocab_size": 256,
+        "emb_dim": 16,
+        "multiple_of": 2,
+        "nheads": 2,
+        "nlayers": 2,
+        "norm_eps": 1e-05,
+        "pad_id": 0,
+    }
+    config = LLaMAConfig(**params)
+    model = LLaMA(**params)
+    assert model.get_config().as_dict() == config.as_dict()
+
+
+def test_config_passed_to_model():
+    config = LLaMAConfig(
+        src_vocab_size=256,
+        emb_dim=16,
+        multiple_of=2,
+        nheads=2,
+        nlayers=2,
+        norm_eps=1e-05,
+        pad_id=0,
+    )
+    model = LLaMA(config)
+    assert model.get_config().as_dict() == config.as_dict()
+
+
+def test_config_passed_to_model_and_updated():
+    config = LLaMAConfig(
+        src_vocab_size=256,
+        emb_dim=16,
+        multiple_of=2,
+        nheads=2,
+        nlayers=2,
+        norm_eps=1e-05,
+        pad_id=0,
+    )
+    model = LLaMA(config, pad_id=1)
+    # check not same reference
+    assert model.get_config() is not config
+
+    # modify pad_id to the new value expected and check equivalence
+    config.pad_id = 1
+    assert model.get_config().as_dict() == config.as_dict()

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,0 +1,36 @@
+import dataclasses
+import os.path
+import tempfile
+
+from fms.utils.config import ModelConfig
+
+
+@dataclasses.dataclass
+class MockModelConfig(ModelConfig):
+    required_a: int
+    default_b: str = "default"
+
+
+def test_round_trip():
+    config = MockModelConfig(required_a=1)
+    with tempfile.TemporaryDirectory() as workdir:
+        config_path = f"{workdir}/config.json"
+        assert not os.path.exists(config_path)
+        config.save(config_path)
+        assert os.path.exists(config_path) and os.path.isfile(config_path)
+        config_loaded = MockModelConfig.load(config_path)
+        assert config.required_a == config_loaded.required_a
+        assert config.default_b == config_loaded.default_b
+
+
+def test_as_dict():
+    config = MockModelConfig(required_a=1, default_b="other_default")
+    assert config.as_dict() == {"required_a": 1, "default_b": "other_default"}
+
+
+def test_updated():
+    config = MockModelConfig(required_a=1, default_b="other_default")
+    config_updated = config.updated(required_a=2)
+    assert config is not config_updated
+    assert config_updated.required_a == 2
+    assert config_updated.default_b == "other_default"


### PR DESCRIPTION
Fixed an issue where when adding a config as well as kwargs to a LLaMA model, the update was in place. Now update_config for ModelConfig will perform a deep copy and return a new instance of the ModelConfig with params overridden.