### PR TITLE
add a script to verify inference performance

### DIFF
--- a/examples/benchmark_inference.py
+++ b/examples/benchmark_inference.py
@@ -86,6 +86,16 @@ ids = torch.randint(
     tokenizer.vocab_size(), (BATCH_SIZE, SEQ_LEN), device=device, dtype=torch.long
 )
 
+# This first forward call generates the cache for use in cases where
+# `use_cache=True`.
+#
+# For performance purposes, this call can be considered equivalent to
+# `use_cache=False`.
+#
+# The actual performance of generation with `use_cache=True` would be the cost
+# of the first token without cache, plus the cost of all subsequent tokens with
+# cache. I.e. the amortized per-token cost would depend on the number of tokens
+# generated.
 logits, cache = model.forward(ids, use_cache=True)
 logits = logits[:, -1, :]
 next_val = torch.argmax(logits, dim=-1).unsqueeze(0).t()


### PR DESCRIPTION
The output of the script looks like:

```
$ srun -N 1 --gres=gpu:1 torchrun --nproc_per_node=1 ./examples/benchmark_inference.py --model_path=~/models/7B-F/ --tokenizer=~/models/tokenizer.model --batch_size=2 --seq_len=500
loading model
loading complete on rank 0
Uncompiled results:
- with use_cache=True, excluding first call
        35.20 ms per token
- without cache
        91.87 ms per token
Compiling model...

Compiled results:
- with use_cache=True, excluding first call
        21.31 ms per token
- without cache
        72.23 ms per token
```

This validates expected performance as previously described from other benchmarks @ani300 ran internally on another variant of the code.

This script also uncovered a graph break issue, which was fixed in https://github.com/ibm-pytorch/foundation-model-stack/pull/25


