### PR TITLE
rename "examples" to "scripts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ or
 python setup.py install
 ```
 
-An example of inference on our implementation of LLaMA can be found in `examples/inference.py`.
+An example of inference on our implementation of LLaMA can be found in `scripts/inference.py`.
 
 
 ## Inference

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -11,7 +11,7 @@ from fms.models.llama import load_fms_llama
 
 # Example running llama 7B on one A100:
 #
-# $ srun -N 1 --gres=gpu:1 torchrun --nproc_per_node=1 ./examples/benchmark_inference.py --model_path=~/models/7B-F/ --tokenizer=~/models/tokenizer.model --batch_size=2 --seq_len=500
+# $ srun -N 1 --gres=gpu:1 torchrun --nproc_per_node=1 ./scripts/benchmark_inference.py --model_path=~/models/7B-F/ --tokenizer=~/models/tokenizer.model --batch_size=2 --seq_len=500
 # loading model
 # loading complete on rank 0
 # Uncompiled results:

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -13,9 +13,9 @@ from fms.utils.generation import generate
 # This example script validates the LLaMA implementation by running inference on a couple of prompts.
 #
 # Example usage with single-GPU 7B model on slurm, with torch.compile and determinstic behavior:
-# CUBLAS_WORKSPACE_CONFIG=:4096:8 srun -N 1 --gres=gpu:1 python examples/inference.py --model_path=~/models/7B-F/ --tokenizer=~/models/tokenizer.model --compile --deterministic
+# CUBLAS_WORKSPACE_CONFIG=:4096:8 srun -N 1 --gres=gpu:1 python scripts/inference.py --model_path=~/models/7B-F/ --tokenizer=~/models/tokenizer.model --compile --deterministic
 # Example usage of 13B model on 2 GPUs with Tensor Parallel:
-# srun -N 1 --gres=gpu:2 torchrun --nproc_per_node=2 ~/repos/newfms/examples/inference.py --model_path=~/models/13-F --tokenizer=~/models/tokenizer.model --distributed
+# srun -N 1 --gres=gpu:2 torchrun --nproc_per_node=2 scripts/inference.py --model_path=~/models/13B-F --tokenizer=~/models/tokenizer.model --distributed
 
 parser = argparse.ArgumentParser(description="Script to run inference on a LLaMA model")
 parser.add_argument("--device_type", type=str, default="cuda")


### PR DESCRIPTION
I think this is a better name since it's not just "examples" but also a benchmarking script, and will likely eventually contain other scripts too.
