### PR TITLE
Updated all_gather to prevent excessive recompilation during generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     author_email="bvaughan@ibm.com",
     description="IBM Foundation Model Stack",
     packages=find_packages(),
-    install_requires= [], #["torch >= 2.0"],
+    install_requires=[],  # ["torch >= 2.0"],
 )


### PR DESCRIPTION
As the PR title says, all_gather as it was was causing a lot of recompilations during torch.compile(). This code trades some memory copies for many less compilations, which is required for fast compilation cache warmups.