### PR TITLE
remove branch filter because limits compatibility with ghstack

### DIFF
--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -2,11 +2,7 @@
 
 name: FMS Testing
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
when using ghstack, this workflow wasn't running because the `on` filters by branch.

We'll still need to do https://github.com/foundation-model-stack/foundation-model-stack/issues/43 before we'd be able to use ghstack but this change removes one barrier.
