### PR TITLE
Llama conversion

### DIFF
--- a/scripts/llama_conversion.py
+++ b/scripts/llama_conversion.py
@@ -1,0 +1,24 @@
+from transformers import LlamaForCausalLM
+from transformers import LlamaTokenizer
+from fms.models.hf.llama.modeling_llama_hf import LLaMAHFForCausalLM
+
+import fms.models.llama as llama
+
+def convert_from_hf_to_fms(path_to_hf_model, path_to_fms_model):
+    """Convert the HF checkpoints to FMS checkpoints to be used by this repo
+
+    Args:
+        path_to_hf_model (str): Path on disk to the HF checkpoint including the tokenizer
+        path_to_fms_model (_type_): Path to save the FMS checkpoint including the tokenizer
+    """
+    # load the HF model and the tokenizer
+    model = LLaMAHFForCausalLM.from_pretrained(path_to_hf_model)
+    tokenizer = LlamaTokenizer.from_pretrained(path_to_hf_model)
+    
+    # convert to FMS HF
+    fms_llama = llama.convert_hf_llama(model)
+    fms_hf_llama = LLaMAHFForCausalLM.from_fms_model(fms_llama)
+    
+    # save checkpoint
+    fms_hf_llama.save_pretrained(path_to_fms_model)
+    

--- a/scripts/llama_conversion.py
+++ b/scripts/llama_conversion.py
@@ -4,6 +4,9 @@ from fms.models.hf.llama.modeling_llama_hf import LLaMAHFForCausalLM
 
 import fms.models.llama as llama
 
+import argparse
+import os
+
 def convert_from_hf_to_fms(path_to_hf_model, path_to_fms_model):
     """Convert the HF checkpoints to FMS checkpoints to be used by this repo
 
@@ -22,3 +25,22 @@ def convert_from_hf_to_fms(path_to_hf_model, path_to_fms_model):
     # save checkpoint
     fms_hf_llama.save_pretrained(path_to_fms_model)
     
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input_dir",
+        help="Location of HF LLaMA weights, which contains the model weights and the tokenizer",
+        required=True
+    )
+    
+    parser.add_argument(
+        "--output_dir",
+        help="Target location for FMS LLaMa weights"
+        required=True
+    )
+    
+    args = parser.parse_args()
+    convert_from_hf_to_fms(args.input_dir, args.output_dir)
+    
+if __name__ == "__main__":
+    main()

--- a/scripts/llama_conversion.py
+++ b/scripts/llama_conversion.py
@@ -22,8 +22,9 @@ def convert_from_hf_to_fms(path_to_hf_model, path_to_fms_model):
     fms_llama = llama.convert_hf_llama(model)
     fms_hf_llama = LLaMAHFForCausalLM.from_fms_model(fms_llama)
     
-    # save checkpoint
+    # save checkpoint and tokenizer
     fms_hf_llama.save_pretrained(path_to_fms_model)
+    tokenizer.save_pretrained(path_to_fms_model)
     
 def main():
     parser = argparse.ArgumentParser()

--- a/scripts/llama_conversion.py
+++ b/scripts/llama_conversion.py
@@ -15,7 +15,7 @@ def convert_from_hf_to_fms(path_to_hf_model, path_to_fms_model):
         path_to_fms_model (_type_): Path to save the FMS checkpoint including the tokenizer
     """
     # load the HF model and the tokenizer
-    model = LLaMAHFForCausalLM.from_pretrained(path_to_hf_model)
+    model = LlamaForCausalLM.from_pretrained(path_to_hf_model)
     tokenizer = LlamaTokenizer.from_pretrained(path_to_hf_model)
     
     # convert to FMS HF
@@ -40,6 +40,7 @@ def main():
     )
     
     args = parser.parse_args()
+    
     convert_from_hf_to_fms(args.input_dir, args.output_dir)
     
 if __name__ == "__main__":

--- a/scripts/llama_conversion.py
+++ b/scripts/llama_conversion.py
@@ -35,7 +35,7 @@ def main():
     
     parser.add_argument(
         "--output_dir",
-        help="Target location for FMS LLaMa weights"
+        help="Target location for FMS LLaMa weights",
         required=True
     )
     


### PR DESCRIPTION
The PR captures the LLama model weights conversion from HF to FMS. This is done through a simple script and calling it as follows:

```
python foundation-model-stack/scripts/llama_conversion.py --input_dir=<input_path_to_hf_model> --output_dir=<output_path_to_store_fms_weights>
```

Tested with 7 and 13B models and it converts successfully, the weights equality themselves have not been tested. We also need to address 70B conversion separately.