### PR TITLE
Fix all_gather dimension mismatch

### DIFF
--- a/fms/distributed/tensorparallel.py
+++ b/fms/distributed/tensorparallel.py
@@ -101,11 +101,11 @@ def _all_gather(input_: torch.Tensor) -> torch.Tensor:
     last_dim = input_.dim() - 1
     return (
         _all_gather_tensor(
-            input_.transpose_(0, last_dim).contiguous(),
-            last_dim,
+            input_.transpose(0, last_dim).contiguous(),
+            0,
             list(range(world_size)),
         )
-        .transpose_(0, last_dim)
+        .transpose(0, last_dim)
         .contiguous()
     )
 

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -348,7 +348,7 @@ def _rename_weights_to_fms(orig_sd):
     return new_sd
 
 
-def load_fms_llama(model_path: str, group=None):
+def load_fms_llama(model_path: str, group=None, **kwargs):
     if torch.distributed.is_initialized() and group is None:
         group = torch.distributed.GroupMember.WORLD
 
@@ -379,7 +379,7 @@ def load_fms_llama(model_path: str, group=None):
     # IBM LLaMa
     fms_sd = _rename_weights_to_fms(checkpoint_sd)
 
-    extra_args = {}
+    extra_args = kwargs
     if world_size > 1:
         print("using tensor parallel")
         extra_args["distributed_strategy"] = TensorParallelStrategy()

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -173,4 +173,5 @@ use_cache = [
     False
 ]  # True/False are identical with greedy iff `torch.use_deterministic_algorithms(True)`
 for sample, cache in itertools.product(do_sample, use_cache):
-    infer(cache, sample)
+    with torch.no_grad():
+        infer(cache, sample)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -68,6 +68,7 @@ print("loading model")
 model = load_fms_llama(args.model_path)
 tokenizer = tokenizers.get_tokenizer(args.tokenizer)
 model.eval()
+torch.set_grad_enabled(False)
 print("loading complete on rank", local_rank)
 
 if args.compile:
@@ -170,5 +171,4 @@ use_cache = [
     False
 ]  # True/False are identical with greedy iff `torch.use_deterministic_algorithms(True)`
 for sample, cache in itertools.product(do_sample, use_cache):
-    with torch.no_grad():
-        infer(cache, sample)
+    infer(cache, sample)


### PR DESCRIPTION
This fixes `all_gather` dimensions not being correct, as after adding the transpose we forgot to change the dimension where we're gathering.

Two smaller fixes: this prevents a graph break during the `all_gather `autograd function by activating torch.no_grad() (see https://github.com/pytorch/pytorch/issues/107824 for more details), and adds the ability to pass kwargs to llama model init from the `load_fms_llama` function.