### PR TITLE
switched to logger for unknown parameters given to updated method in ModelConfig

### DIFF
--- a/fms/utils/config.py
+++ b/fms/utils/config.py
@@ -4,6 +4,9 @@ import json
 import os
 from dataclasses import asdict, dataclass
 from typing import Union
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -46,9 +49,14 @@ class ModelConfig:
         """
         # create a deep copy as we don't want to modify this reference
         copied_config = copy.deepcopy(self)
+        unknown_params = []
         for k, v in kwargs.items():
             if hasattr(copied_config, k):
                 setattr(copied_config, k, v)
             else:
-                print(f"Warning: unknown parameter {k}")
+                unknown_params.append(k)
+        if len(unknown_params) > 0:
+            logger.debug(
+                f"""Found the following unknown parameters while cloning and updating the configuration: {unknown_params}"""
+            )
         return copied_config

--- a/fms/utils/config.py
+++ b/fms/utils/config.py
@@ -56,7 +56,7 @@ class ModelConfig:
             else:
                 unknown_params.append(k)
         if len(unknown_params) > 0:
-            logger.debug(
+            logger.info(
                 f"""Found the following unknown parameters while cloning and updating the configuration: {unknown_params}"""
             )
         return copied_config

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -38,7 +38,7 @@ def test_updated():
 
 
 def test_updated_unknown_params_message(caplog):
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.INFO)
     config = MockModelConfig(required_a=1, default_b="other_default")
     config.updated(required_a=2, unknown_param_1=3, unknown_param_2=4)
     assert (

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,3 +1,4 @@
+import logging
 import dataclasses
 import os.path
 import tempfile
@@ -34,3 +35,13 @@ def test_updated():
     assert config is not config_updated
     assert config_updated.required_a == 2
     assert config_updated.default_b == "other_default"
+
+
+def test_updated_unknown_params_message(caplog):
+    caplog.set_level(logging.DEBUG)
+    config = MockModelConfig(required_a=1, default_b="other_default")
+    config.updated(required_a=2, unknown_param_1=3, unknown_param_2=4)
+    assert (
+        """Found the following unknown parameters while cloning and updating the configuration: ['unknown_param_1', 'unknown_param_2']"""
+        in caplog.text.strip()
+    )


### PR DESCRIPTION
When calling updated method on a ModelConfig with unknown parameters given, we would get a lot of prints, which was not intended. Now using logger debug for print statements when unknown params given to updated method in ModelConfig. This was occurring because the PretrainedConfig (HF) equivalent config had more params than what was in the ModelConfig and ModelConfig would just ignore them, however print a message. 

Note: We may want to consider also inspecting the dataclass to only pass those params that exist when converting from hf config to fms-hf config.