### PR TITLE
AutoModel support for HFAdaptedLLaMAHeadless and AutoModel/AutoConfig test cases

### DIFF
--- a/fms/models/hf/llama/__init__.py
+++ b/fms/models/hf/llama/__init__.py
@@ -9,7 +9,7 @@ def get_model(model_name_or_path: Union[str, os.PathLike]) -> HFAdaptedLLaMAForC
 
     Parameters
     ----------
-    model_path_or_name: Union[str, os.PathLike]
+    model_name_or_path: Union[str, os.PathLike]
         Either the name of the model in huggingface hub or the absolute path to
         the huggingface model
 

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -8,11 +8,12 @@ def register_fms_models():
     (AutoConfig, AutoModel, AutoModelForSeq2SeqLM) and Granite (AutoConfig, AutoModel, AutoModelForCausalLM)"""
     from fms.models.hf.llama.modeling_llama_hf import (
         HFAdaptedLLaMAConfig,
+        HFAdaptedLLaMAHeadless,
         HFAdaptedLLaMAForCausalLM,
     )
 
     AutoConfig.register("hf_adapted_llama", HFAdaptedLLaMAConfig)
-    AutoModel.register(HFAdaptedLLaMAConfig, HFAdaptedLLaMAForCausalLM)
+    AutoModel.register(HFAdaptedLLaMAConfig, HFAdaptedLLaMAHeadless)
     AutoModelForCausalLM.register(HFAdaptedLLaMAConfig, HFAdaptedLLaMAForCausalLM)
 
 

--- a/fms/testing/_internal/hf/model_test_suite.py
+++ b/fms/testing/_internal/hf/model_test_suite.py
@@ -193,7 +193,8 @@ class HFAutoModelTestSuite(HFModelFixtureMixin):
                 isinstance(fms_hf_model, type(new_model)) and new_model.lm_head is None
             )
 
-    def test_hf_automodel_text_generation(self, fms_hf_model: PreTrainedModel):
+    def test_hf_automodel_language_modeling_head(self, fms_hf_model: PreTrainedModel):
+        """test that the language modeling head model can be loaded with automodel"""
         if isinstance(fms_hf_model, HFEncoderDecoderModelArchitecture):
             automodel_class = AutoModelForSeq2SeqLM
         elif isinstance(fms_hf_model, HFDecoderModelArchitecture):

--- a/fms/testing/_internal/hf/model_test_suite.py
+++ b/fms/testing/_internal/hf/model_test_suite.py
@@ -5,6 +5,11 @@ import torch
 from torch._dynamo.exc import TorchDynamoException
 from torch._dynamo.testing import CompileCounterWithBackend
 
+from fms.models.hf.modeling_hf_adapter import (
+    HFEncoderDecoderModelArchitecture,
+    HFDecoderModelArchitecture,
+)
+from fms.models.hf.utils import register_fms_models
 from fms.testing._internal.model_test_suite import ConfigFixtureMixin
 
 SEED = 42
@@ -28,6 +33,10 @@ from transformers import (
     AutoTokenizer,
     PreTrainedTokenizer,
     PretrainedConfig,
+    AutoConfig,
+    AutoModel,
+    AutoModelForSeq2SeqLM,
+    AutoModelForCausalLM,
 )
 
 from fms.utils.config import ModelConfig
@@ -115,6 +124,15 @@ class HFConfigTestSuite(ConfigFixtureMixin, HFConfigFixtureMixin):
             )
             assert fms_hf_config.to_dict() == fms_hf_config_loaded.to_dict()
 
+    def test_hf_autoconfig(self, fms_hf_config: PretrainedConfig):
+        """test that the config can be loaded with autoconfig after registration"""
+        register_fms_models()
+        with tempfile.TemporaryDirectory() as workdir:
+            fms_hf_config_path = f"{workdir}/hf_config.json"
+            fms_hf_config.save_pretrained(fms_hf_config_path)
+            new_config = AutoConfig.from_pretrained(fms_hf_config_path)
+            assert isinstance(new_config, type(fms_hf_config))
+
 
 class HFModelCompileTestSuite(HFModelFixtureMixin):
     """A set of tests associated with compilation of huggingface adapted fms models"""
@@ -161,6 +179,35 @@ class HFModelCompileTestSuite(HFModelFixtureMixin):
             assert cnt.frame_count == 1
         except TorchDynamoException as e:
             pytest.fail(f"Failed to get signature of full-graph compiled model:\n{e}")
+
+
+class HFAutoModelTestSuite(HFModelFixtureMixin):
+    def test_hf_automodel_headless(self, fms_hf_model: PreTrainedModel):
+        """test that the headless model can be loaded with automodel after registration"""
+        register_fms_models()
+        with tempfile.TemporaryDirectory() as workdir:
+            fms_hf_model_path = f"{workdir}/hf_model"
+            fms_hf_model.save_pretrained(fms_hf_model_path)
+            new_model = AutoModel.from_pretrained(fms_hf_model_path)
+            assert (
+                isinstance(fms_hf_model, type(new_model)) and new_model.lm_head is None
+            )
+
+    def test_hf_automodel_text_generation(self, fms_hf_model: PreTrainedModel):
+        if isinstance(fms_hf_model, HFEncoderDecoderModelArchitecture):
+            automodel_class = AutoModelForSeq2SeqLM
+        elif isinstance(fms_hf_model, HFDecoderModelArchitecture):
+            automodel_class = AutoModelForCausalLM
+        else:
+            pytest.skip(
+                "encoder-only models do not perform text generation and therefore do not use AutoModelForCausalLM or AutoModelForSeq2SeqLM"
+            )
+        register_fms_models()
+        with tempfile.TemporaryDirectory() as workdir:
+            fms_hf_model_path = f"{workdir}/hf_model"
+            fms_hf_model.save_pretrained(fms_hf_model_path)
+            new_model = automodel_class.from_pretrained(fms_hf_model_path)
+            assert isinstance(new_model, type(fms_hf_model))
 
 
 class HFModelEquivalenceTestSuite(HFConfigFixtureMixin, HFModelFixtureMixin):

--- a/tests/models/hf/test_llama_hf.py
+++ b/tests/models/hf/test_llama_hf.py
@@ -1,5 +1,4 @@
 import pytest
-from torch import nn as nn
 from transformers import (
     PreTrainedModel,
     LlamaForCausalLM,
@@ -19,6 +18,7 @@ from fms.testing._internal.hf.model_test_suite import (
     HFModelEquivalenceTestSuite,
     HFModelGenerationTestSuite,
     HFModelCompileTestSuite,
+    HFAutoModelTestSuite,
 )
 from fms.testing._internal.model_test_suite import ModelFixtureMixin
 from ..test_llama import LLaMA2Fixtures, LLaMA2GQAFixtures
@@ -145,6 +145,7 @@ class TestLLaMA2HF(
     HFModelEquivalenceTestSuite,
     HFModelGenerationTestSuite,
     HFModelCompileTestSuite,
+    HFAutoModelTestSuite,
     LLaMA2Fixtures,
     LLaMA2HFFixtures,
 ):
@@ -166,6 +167,7 @@ class TestLLaMA2GQAHF(
     HFModelEquivalenceTestSuite,
     HFModelGenerationTestSuite,
     HFModelCompileTestSuite,
+    HFAutoModelTestSuite,
     LLaMA2GQAFixtures,
     LLaMA2HFFixtures,
 ):


### PR DESCRIPTION
- added AutoModel support for  HFAdaptedLLaMAHeadless
- added test suite for automodel/autoconfig in hf adapters model_test_suite
- fixed minor docstring param name in get_model for llama