### PR TITLE
add an expandable tensor

### DIFF
--- a/fms/utils/tensors.py
+++ b/fms/utils/tensors.py
@@ -47,7 +47,7 @@ class ExpandableTensor(torch.Tensor):
             )
             self.tensor().copy_(tensor)
 
-    def __new__(cls, tensor, dim, preallocate_length):
+    def __new__(cls, tensor, dim=0, preallocate_length=None):
         return super().__new__(cls)
 
     def size(self):
@@ -112,7 +112,7 @@ class ExpandableTensor(torch.Tensor):
                 tensor.tensor() if type(tensor) == ExpandableTensor else tensor
                 for tensor in tensors
             ]
-            torch.cat(tensors, dim, out=out)
+            return torch.cat(tensors, dim, out=out)
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/fms/utils/tensors.py
+++ b/fms/utils/tensors.py
@@ -50,8 +50,12 @@ class ExpandableTensor(torch.Tensor):
     def __new__(cls, tensor, dim=0, preallocate_length=None):
         return super().__new__(cls)
 
-    def size(self):
-        return self._tensor().size()
+    def size(self, dim=None):
+        # https://github.com/pytorch/pytorch/issues/111944
+        if dim is None:
+            return self._tensor().size()
+        else:
+            return self._tensor().size(dim=dim)
 
     def _append(self, tensor):
         """

--- a/fms/utils/tensors.py
+++ b/fms/utils/tensors.py
@@ -1,0 +1,126 @@
+import torch
+
+import functools
+
+_HANDLED_FUNCTIONS = {}
+
+
+def _implements(torch_function):
+    """Register a torch function override"""
+
+    def decorator(func):
+        functools.update_wrapper(func, torch_function)
+        _HANDLED_FUNCTIONS[torch_function] = func
+        return func
+
+    return decorator
+
+
+class ExpandableTensor(torch.Tensor):
+    """
+    This tensor behaves similarly to a java ArrayList along a specified
+    dimension. It preallocates space along that dimension, and has an append
+    operation that utilizes this space. This can be more efficient than
+    performing many consecutive torch.cat operations.
+
+    When preallocated space is exhasted, the internal length is doubled.
+    All operations performed on this tensor use a view that truncates the
+    un-utilized preallocated space.
+
+    Args:
+        tensor: the initial values to hold in this tensor.
+        dim: the expandable dimension
+        preallocate_length: the total amount of space to allocate along
+            dimension `dim`
+    """
+
+    def __init__(self, tensor, dim=0, preallocate_length=None):
+        super().__init__()
+        self._dim = dim
+        self._dim_length = tensor.shape[dim]
+        self._tensor = tensor
+        if preallocate_length is not None and preallocate_length > self._dim_length:
+            sizes = list(tensor.size())
+            sizes[dim] = preallocate_length
+            self._tensor = torch.empty(
+                size=sizes, dtype=tensor.dtype, device=tensor.device
+            )
+            self.tensor().copy_(tensor)
+
+    def __new__(cls, tensor, dim, preallocate_length):
+        return super().__new__(cls)
+
+    def size(self):
+        return self.tensor().size()
+
+    def append(self, tensor):
+        """
+        Returns a tensor equivalent to the result of
+        `torch.cat( (self, tensor), dim=self._dim)`, possibly modifying `self`
+        in-place to make use of preallocated space.
+        """
+        dim = self._dim
+        expected = list(self._tensor.size())
+        tensor_sizes = list(tensor.size())
+        for i in range(len(expected)):
+            if i != dim:
+                assert expected[i] == tensor_sizes[i]
+        if self.size()[dim] + tensor.size()[dim] <= self._tensor.size()[dim]:
+            # copy into tail of _tensor
+            view = self._tensor
+            sizes = list(view.size())
+            sizes[self._dim] = tensor.size()[dim]
+            strides = self._tensor.stride()
+            offset = self._dim_length * strides[self._dim]
+            view = view.as_strided(size=sizes, stride=strides, storage_offset=offset)
+            view.copy_(tensor)
+            self._dim_length += tensor.shape[dim]
+            return self
+        else:
+            # create new expandable tensor
+            expanded = ExpandableTensor(
+                self.tensor(), self._dim, self._tensor.shape[dim] * 2
+            )
+            return expanded.append(tensor)
+
+    def tensor(self):
+        """
+        Returns a view of the tensor excluding preallocated space
+        """
+        view = self._tensor
+        sizes = list(view.size())
+        sizes[self._dim] = self._dim_length
+        view = view.as_strided(size=sizes, stride=view.stride())
+        return view
+
+    def __repr__(self):
+        return self.tensor().__repr__()
+
+    @_implements(torch.cat)
+    def cat(tensors, dim=0, *, out=None):
+        if (
+            len(tensors)
+            and type(tensors[0] == ExpandableTensor)
+            and tensors[0]._dim == dim
+        ):
+            result = tensors[0]
+            for tensor in tensors[1:]:
+                result = result.append(tensor)
+            return result
+        else:
+            tensors = [
+                tensor.tensor() if type(tensor) == ExpandableTensor else tensor
+                for tensor in tensors
+            ]
+            torch.cat(tensors, dim, out=out)
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if func not in _HANDLED_FUNCTIONS or not all(
+            issubclass(t, (torch.Tensor, ExpandableTensor)) for t in types
+        ):
+            args = [a.tensor() if hasattr(a, "tensor") else a for a in args]
+            return func(*args, **kwargs)
+        return _HANDLED_FUNCTIONS[func](*args, **kwargs)

--- a/tests/utils/test_tensors.py
+++ b/tests/utils/test_tensors.py
@@ -68,11 +68,21 @@ def test_perf():
         result = torch.cat((result, next_val), dim=2)
     regular_time = time.time() - start
 
-    t = ExpandableTensor(t)
     result = t
     start = time.time()
+    t = ExpandableTensor(t)
     for _ in range(iters):
         result = torch.cat((result, next_val), dim=2)
     expandable_time = time.time() - start
-    # requires that expandable tensor be at least 2x faster
-    assert expandable_time < (regular_time / 2)
+    # requires that expandable tensor be at least 20% faster
+    assert expandable_time < (regular_time * 0.8)
+
+
+def test_contiguous():
+    t = torch.randn((5, 5))
+    expandable = ExpandableTensor(t, preallocate_length=100)
+    expandable = expandable.contiguous()
+
+    torch.testing.assert_close(expandable, t)
+    assert expandable.is_contiguous()
+    assert type(expandable) != ExpandableTensor

--- a/tests/utils/test_tensors.py
+++ b/tests/utils/test_tensors.py
@@ -15,15 +15,15 @@ def test_expandable_tensor():
     # 8 + 3*4 == 20
     for i in range(4):
         expected = torch.cat((expected, to_append), dim=2)
-        expandable = expandable.append(to_append)
+        expandable = expandable._append(to_append)
 
     torch.testing.assert_close(expandable, expected)
 
     # the "preallocated length" began at 10, then would have expanded 1x and is now exactly full.
-    assert expandable._tensor.shape[2] == 20
+    assert expandable._underlying_tensor.shape[2] == 20
     # expand again doubles it
-    expandable = expandable.append(to_append)
-    assert expandable._tensor.shape[2] == 40
+    expandable = expandable._append(to_append)
+    assert expandable._underlying_tensor.shape[2] == 40
 
 
 def test_expandable_tensor_ops():
@@ -52,7 +52,7 @@ def test_cat():
     torch.testing.assert_close(expandable, expected)
     assert type(expected) != ExpandableTensor
     assert type(expandable) == ExpandableTensor
-    assert expandable._tensor.shape[2] == 20
+    assert expandable._underlying_tensor.shape[2] == 20
 
 
 def test_perf():

--- a/tests/utils/test_tensors.py
+++ b/tests/utils/test_tensors.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from fms.utils.tensors import ExpandableTensor
+
+
+def test_expandable_tensor():
+    t = torch.randn((4, 5, 8, 7))
+    expandable = ExpandableTensor(t, 2, 10)
+
+    to_append = torch.randn((4, 5, 3, 7))
+
+    expected = t
+    # 8 + 3*4 == 20
+    for i in range(4):
+        expected = torch.cat((expected, to_append), dim=2)
+        expandable = expandable.append(to_append)
+
+    torch.testing.assert_close(expandable, expected)
+
+    # the "preallocated length" began at 10, then would have expanded 1x and is now exactly full.
+    assert expandable._tensor.shape[2] == 20
+    # expand again doubles it
+    expandable = expandable.append(to_append)
+    assert expandable._tensor.shape[2] == 40
+
+
+def test_expandable_tensor_ops():
+    t = torch.randn((4, 5, 8, 7))
+    expandable = ExpandableTensor(t, 2, 10)
+    # validate an arbitrary tensor operation
+    expandable.add_(7)
+    t.add_(7)
+    torch.testing.assert_close(expandable, t)
+    # in place op preserves type, no copy
+    assert type(expandable) == ExpandableTensor
+
+
+def test_cat():
+    t = torch.randn((4, 5, 8, 7))
+    expandable = ExpandableTensor(t, 2, 10)
+
+    to_append = torch.randn((4, 5, 3, 7))
+
+    expected = t
+    # 8 + 3*4 == 20
+    for i in range(4):
+        expected = torch.cat((expected, to_append), dim=2)
+        expandable = torch.cat((expandable, to_append), dim=2)
+
+    torch.testing.assert_close(expandable, expected)
+    assert type(expandable) == ExpandableTensor
+    assert expandable._tensor.shape[2] == 20


### PR DESCRIPTION
adds an expandable tensor that uses preallocated space to avoid excessive copying on repeated torch.cat operations.

The hope is that this may be useful as an optimization for kv caching, by preallocating the kv cache space.

See: https://github.com/foundation-model-stack/foundation-model-stack/pull/84
