### PR TITLE
cat of expandable shouldn't change _dim_length in-place

### DIFF
--- a/tests/utils/test_tensors.py
+++ b/tests/utils/test_tensors.py
@@ -40,6 +40,7 @@ def test_expandable_tensor_ops():
 def test_cat():
     t = torch.randn((4, 5, 8, 7))
     expandable = ExpandableTensor(t, 2, 10)
+    original = expandable
 
     to_append = torch.randn((4, 5, 3, 7))
 
@@ -53,6 +54,9 @@ def test_cat():
     assert type(expected) != ExpandableTensor
     assert type(expandable) == ExpandableTensor
     assert expandable._underlying_tensor.shape[2] == 20
+
+    # original should not have changed
+    assert original.shape == (4, 5, 8, 7)
 
 
 def test_perf():


### PR DESCRIPTION
bugfix. torch.cat is still in-place, and so modifications to the original tensor will still be reflected, but the cat operation itself shouldn't result in the original `expandable` having a new `.size()`.
