### PR TITLE
get_model for HF adapted llama conversion now carries pad_token_id over from hf model

### DIFF
--- a/fms/models/hf/llama/__init__.py
+++ b/fms/models/hf/llama/__init__.py
@@ -27,6 +27,12 @@ def get_model(model_name_or_path: Union[str, os.PathLike]) -> HFAdaptedLLaMAForC
     hf_model = LlamaForCausalLM.from_pretrained(model_name_or_path)
     fms_model = convert_hf_llama(hf_model).half()
     result_model: HFAdaptedLLaMAForCausalLM = HFAdaptedLLaMAForCausalLM.from_fms_model(
-        fms_model, torch_dtype=torch.float16
+        fms_model,
+        torch_dtype=torch.float16,
+        # pad_token_id in fms is defaulted to -1
+        # in generation, huggingface will add pad_tokens to the end of a sequence after the eos token is found for a
+        # given sequence in the batch, if -1 is provided, our model won't be able to interpret it. We should be using
+        # huggingface pad_token_id as that is where the model weights are coming from.
+        pad_token_id=hf_model.config.pad_token_id,
     )
     return result_model


### PR DESCRIPTION
fixed issue where hf conversion to fms adapted hf model (get_model) does not carry over pad_token_id. This issue came about from errors when Huggingface generation is called on a batch where one of the sequences in the batch terminates early.