### PR TITLE
An API for loading from a variety of available model checkpoints

### DIFF
--- a/fms/distributed/__init__.py
+++ b/fms/distributed/__init__.py
@@ -1,0 +1,19 @@
+import torch
+
+
+def rank_and_world(group=None):
+    """
+    Returns (rank, world_size) from the optionally-specified group, otherwise
+    from the defult group, or if non-distributed just returns (0, 1)
+    """
+    if torch.distributed.is_initialized() and group is None:
+        group = torch.distributed.GroupMember.WORLD
+
+    if group is None:
+        world_size = 1
+        rank = 0
+    else:
+        world_size = group.size()
+        rank = group.rank()
+
+    return rank, world_size

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -1,10 +1,15 @@
 from contextlib import nullcontext
-import os
-from pathlib import Path
-import re
-from typing import Callable, List
+from typing import Callable
 import torch
 from torch import nn
+from fms import distributed
+from fms.distributed.strategy import (
+    TensorParallelStrategy,
+    UniformModelParallelStrategy,
+)
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, ShardingStrategy
+from torch.distributed.distributed_c10d import ProcessGroup
+from fms.utils import serialization
 
 __models = {}
 
@@ -80,6 +85,159 @@ def get_model(
             return model_factory(**extra_args)
     finally:
         torch.set_default_dtype(orig)
+
+
+def _guess_num_layers(state_dict):
+    """
+    This function attempts to guess the number of "layers" in a state_dict by
+    looking for lists of sub modules. This can be used to setup model-parallel
+    when we don't yet have a model instance.
+    """
+    # really we wouldn't be training a model from scratch with MP, so
+    # I think it's OK to use an arbitrary value. We don't have a config
+    # at this point.
+    if state_dict is None:
+        return 20
+
+    layers = set()
+    import re
+
+    for key in state_dict.keys():
+        # when there's a list of layers, layers have numeric IDs in the key
+        layerid = re.sub("[^.]*\.([0-9]+)\..*", "\\1", key)
+        if layerid != key:
+            layers.add(layerid)
+    return len(layers)
+
+
+# TODO: FSDP configuration isn't tested, more of a placeholder to make sure
+# it fits the rest of the model-loading paradigm being used here. Will be
+# updated along with in-progress tuning script.
+def _fsdp_wrap(model: nn.Module, distributed_strategy, local_rank, sync_module_states):
+    # initializes parameters that are on meta devices
+    def init_fn(x):
+        return x.to_empty()
+
+    if distributed_strategy == "fsdp":
+        dp_strategy = ShardingStrategy.FULL_SHARD
+    elif distributed_strategy == "hsdp":
+        dp_strategy = ShardingStrategy.HYBRID_SHARD
+    elif distributed_strategy == "ddp":
+        dp_strategy = ShardingStrategy.NO_SHARD
+    else:
+        raise KeyError("distributed strategy was supposed to be one of fsdp or hsdp")
+
+    model = FSDP(
+        model,
+        param_init_fn=init_fn,
+        sync_module_states=sync_module_states,
+        device_id=local_rank,
+        limit_all_gathers=True,
+        use_orig_params=True,
+        # TODO: add wrap and mixed precision policies.
+        # auto_wrap_policy=wrapping_policy,
+        # mixed_precision=mp_policy,
+        sharding_strategy=dp_strategy,
+    )
+    # TODO: add activation checkpointing.
+    return model
+
+
+def _is_dp(distributed_strategy):
+    return distributed_strategy in {"fsdp", "hsdp", "ddp"}
+
+
+def load_model(
+    architecture: str,
+    variant: str,
+    model_path: str = None,
+    source: str = None,
+    device_type: str = "cpu",
+    distributed_strategy: str = None,
+    checkpoint_sharding: str = None,
+    group: ProcessGroup = None,
+    **kwargs,
+):
+    """
+    Load an instance of a model with weights.
+
+    Args:
+    architecture: the model architecture, e.g. llama. See
+                `models.list_models()`.
+    variant: the configuration of the model, e.g. 7b. See
+                `models.list_variants(architecture)`
+    model_path: the path to the state_dict of weights
+    device_type: where to load the model
+    distributed_strategy: None, 'fsdp', 'hsdp', 'tp', or 'mp'.
+    checkpoint_sharding: how the checkpoint files are sharded: None, 'tp',
+                'fsdp', or 'layer'. If None, guess based on files.
+    source: If the weights in the state dict didn't come from an FMS model,
+                `source` specifies which conversion function might be needed.
+                See `serialization.list_sources(architecture)`
+    group: ProcessGroup
+    """
+    local_rank, world_size = distributed.rank_and_world(group)
+
+    if distributed_strategy is None or distributed_strategy == "":
+        if world_size > 1:
+            distributed_strategy = "tp"
+        elif torch.cuda.device_count() > 1:
+            distributed_strategy = "mp"
+
+    device = torch.device(device_type, local_rank)
+    initial_device = device
+    if (
+        _is_dp(distributed_strategy)
+        and local_rank != 0
+        and checkpoint_sharding != "fsdp"
+    ):
+        initial_device = "meta"
+
+    fms_sd = serialization.load_state_dict(
+        model_path,
+        distributed_strategy,
+        checkpoint_sharding,
+        initial_device,
+        local_rank,
+        world_size,
+    )
+    fms_sd = serialization.get_adapted(architecture, source, fms_sd)
+
+    extra_args = kwargs
+    if distributed_strategy == "tp":
+        print("using tensor parallel")
+        extra_args["distributed_strategy"] = TensorParallelStrategy()
+    elif distributed_strategy == "mp":
+        print("using model parallel")
+        devices = [i for i in range(torch.cuda.device_count())]
+        extra_args["distributed_strategy"] = UniformModelParallelStrategy(
+            devices, _guess_num_layers(fms_sd)
+        )
+
+    ibm_model = get_model(
+        architecture, variant, device=initial_device, extra_args=extra_args
+    )
+
+    # In some cases we'd need to load the sd before distributing, in some cases
+    # after.
+    # e.g. a checkpoint can be loaded onto rank0 and synced across ranks by
+    # FSDP, but in most cases we need to load the rank-specific checkpoint
+    # onto the current rank.
+    pre_load = (
+        distributed_strategy in ["fsdp", "hsdp"] and checkpoint_sharding != "fsdp"
+    )
+
+    if pre_load and local_rank == 0 and fms_sd is not None:
+        ibm_model.load_state_dict(fms_sd, strict=False)
+
+    # post-init distribution
+    if _is_dp(distributed_strategy):
+        model = _fsdp_wrap(model, distributed_strategy, local_rank, pre_load)
+
+    if not pre_load:
+        ibm_model.load_state_dict(fms_sd, strict=False)
+
+    return ibm_model
 
 
 from fms.models import llama

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -55,11 +55,13 @@ def list_variants(architecture: str):
     return list(__models[architecture].keys())
 
 
-def get_model(
+def _get_model_instance(
     architecture: str, variant: str, *, dtype=None, device=None, extra_args: dict = {}
 ) -> nn.Module:
     """
     Gets a model by name and variant, e.g. `models.get_model('llama', '7b')`
+    Does not load weights.
+    See public API `models.get_model()`
     Args:
     architecture: one of the architectures from list_models(). E.g. llama.
     variant: one of the variants from list_variants(architecture). E.g. '7b'
@@ -147,7 +149,7 @@ def _is_dp(distributed_strategy):
     return distributed_strategy in {"fsdp", "hsdp", "ddp"}
 
 
-def load_model(
+def get_model(
     architecture: str,
     variant: str,
     model_path: Optional[str] = None,
@@ -222,7 +224,7 @@ def load_model(
                 devices, _guess_num_layers(fms_sd)
             )
 
-    fms_model = get_model(
+    fms_model = _get_model_instance(
         architecture, variant, device=initial_device, extra_args=extra_args
     )
 

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -211,15 +211,16 @@ def load_model(
         fms_sd = {}
 
     extra_args = kwargs
-    if distributed_strategy == "tp":
-        print("using tensor parallel")
-        extra_args["distributed_strategy"] = TensorParallelStrategy()
-    elif distributed_strategy == "mp":
-        print("using model parallel")
-        devices = [i for i in range(torch.cuda.device_count())]
-        extra_args["distributed_strategy"] = UniformModelParallelStrategy(
-            devices, _guess_num_layers(fms_sd)
-        )
+    if "distributed_strategy" not in extra_args:
+        if distributed_strategy == "tp":
+            print("using tensor parallel")
+            extra_args["distributed_strategy"] = TensorParallelStrategy()
+        elif distributed_strategy == "mp":
+            print("using model parallel")
+            devices = [i for i in range(torch.cuda.device_count())]
+            extra_args["distributed_strategy"] = UniformModelParallelStrategy(
+                devices, _guess_num_layers(fms_sd)
+            )
 
     fms_model = get_model(
         architecture, variant, device=initial_device, extra_args=extra_args

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -151,7 +151,7 @@ def load_model(
     architecture: str,
     variant: str,
     model_path: Optional[str] = None,
-    source: str = None,
+    source: Optional[str] = None,
     device_type: str = "cpu",
     distributed_strategy: Optional[str] = None,
     checkpoint_sharding: Optional[str] = None,

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -183,7 +183,7 @@ def get_model(
     if distributed_strategy is None or distributed_strategy == "":
         if world_size > 1:
             distributed_strategy = "tp"
-        elif torch.cuda.device_count() > 1:
+        elif torch.cuda.device_count() > 1 and device_type == "cuda":
             distributed_strategy = "mp"
 
     device = torch.device(device_type, local_rank)

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -1,0 +1,132 @@
+from collections import ChainMap, OrderedDict
+import os
+from pathlib import Path
+from typing import Any, List
+import torch
+
+__adapters = {}
+
+
+def register_adapter(architecture: str, source: str, adapter: type):
+    """
+    Registers a state dict adapter to be available to the (de) serialization
+    API.
+
+    Args:
+    architecture: The name of the model architecture, e.g. 'llama'
+    source: A label representing the format of the weights to be converted.
+            E.g. 'hf'
+    adapter: the class of the adapter. The class must accept one constructor
+                parameter, which will be a state dict (`OrderedDict`)
+    """
+    sources = {}
+    if architecture in __adapters:
+        sources = __adapters[architecture]
+    if source in sources:
+        raise KeyError(
+            f"Variant {source} already registered for architecture {architecture}"
+        )
+    sources[source] = adapter
+    __adapters[architecture] = sources
+
+
+def list_sources(architecture: str):
+    """
+    Lists available sources (attribute formats) of a model architecture.
+    E.g. `models.list_variants('llama')` -> ['meta', 'fms', 'hf']
+    Args:
+    architecture: one of the registered architectures returned by
+                    `models.list_models()`.
+    """
+    if architecture not in __adapters:
+        return []
+    return list(__adapters[architecture].keys())
+
+
+def _get_adapter(architecture: str, source: str):
+    if architecture not in __adapters or source not in __adapters[architecture]:
+        # if no adapter is registered, assume the attributes are already in
+        # fms format.
+        # should we raise an error here instead?
+        return lambda x: x
+    return __adapters[architecture][source]
+
+
+def get_adapted(architecture: str, source: str, state_dict: OrderedDict) -> OrderedDict:
+    """
+    Convert a state dict to FMS format, using an adapter specified by name.
+
+    Args:
+    architecture: one of the architectures from `models.list_models()`.
+                    E.g. llama.
+    source: A reference to an attribute format
+    state_dict: the model.state_dict() to be converted/adapted.
+    """
+    adapter = _get_adapter(architecture, source)
+    adapted = adapter(state_dict)
+    return adapted
+
+
+# `models` imports each model class, causing models and adapters to be registered.
+# down here to avoid circular dependencies.
+from fms import models
+
+
+def load_state_dict(
+    model_path: str,
+    distributed_strategy: str = None,
+    checkpoint_sharding: str = None,
+    initial_device: str = None,
+    rank: int = 0,
+    world_size: int = 1,
+):
+    """
+    Validates that the file(s) found at a checkpoint path are copmatible with
+    the intended (possibly distributed) use-case, and returns the state dict
+    if needed.
+
+    Args:
+    model_path: the path to find the weights. If not set, return None.
+    distributed_strategy: the kind of possibly-distributed model in which we
+            intend to load these weights. E.g. tp, fsdp, None. Used for
+            validation.
+    checkpoint_sharding: the sharding format of the checkpoint.
+            E.g. layer, tp, fsdp.
+    initial_device: where the state dict will be loaded. if meta, return None.
+    """
+    if model_path is None or initial_device is "meta":
+        return None
+    # TODO: Add support for tp-sharding a non-sharded state dict.
+    if (
+        distributed_strategy == "tp" or checkpoint_sharding == "tp"
+    ) and distributed_strategy != checkpoint_sharding:
+        raise ValueError(
+            f"TP-sharded models are currently only compatible TP-sharded checkpoints. Attempting to load {checkpoint_sharding} to {distributed_strategy}"
+        )
+    if checkpoint_sharding == "fsdp" and distributed_strategy not in ["fsdp", "hsdp"]:
+        raise ValueError(f"FSDP checkpoints can only be loaded into an FSDP model")
+
+    model_path = Path(os.path.expanduser(model_path))
+    if not model_path.is_dir():
+        checkpoints = [model_path]
+    else:
+        # TODO: add support for safetensors.
+        checkpoints = sorted(model_path.glob("*.pth"))
+        if not len(checkpoints):
+            checkpoints = sorted(model_path.glob("*.bin"))
+
+    if checkpoint_sharding is not None and checkpoint_sharding != "layer":
+        assert world_size == len(
+            checkpoints
+        ), f"Loading a {checkpoint_sharding}-sharded checkpoint with len={len(checkpoints)} but world size is {world_size}"
+
+        checkpoints = [checkpoints[rank]]
+
+    checkpoint_sds = [
+        torch.load(ckpt_path, map_location="cpu") for ckpt_path in checkpoints
+    ]
+    if len(checkpoint_sds) == 1:
+        return checkpoint_sds[0]
+    else:
+        # layer-sharded checkpoints, e.g. as used in HF
+        return ChainMap(*checkpoint_sds)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,5 +1,10 @@
+from collections import ChainMap
+import tempfile
+from pathlib import Path
 import pytest
+import torch
 from fms import models
+from fms.utils import serialization
 
 
 def test_register():
@@ -22,3 +27,46 @@ def test_getmodel():
 def test_list():
     assert "llama" in models.list_models()
     assert "7b" in models.list_variants("llama")
+
+
+def test_load():
+    m = models.get_model("llama", "micro")
+    sd = m.state_dict()
+
+    with tempfile.NamedTemporaryFile() as f:
+        torch.save(sd, f.name)
+        loaded = models.load_model("llama", "micro", f.name)
+
+        keys = loaded.state_dict().keys()
+        first = next(iter(keys))
+        assert keys == sd.keys()
+        torch.testing.assert_close(loaded.state_dict()[first], sd[first])
+    with tempfile.TemporaryDirectory() as d:
+        keys = sd.keys()
+        count = 0
+        dicts = []
+        current = {}
+        for key in keys:
+            count += 1
+            current |= {key: sd[key]}
+            if count % 10 == 0:
+                dicts.append(current)
+                current = {}
+
+        dicts.append(current)
+        for i in range(len(dicts)):
+            path = Path(d) / f"{i}.pth"
+            torch.save(dicts[i], path)
+        newsd = serialization.load_state_dict(d)
+        as_loaded = models.load_model("llama", "micro", d).state_dict()
+        # this style load, layer-sharded, has to stitch together the state dicts.
+        assert type(newsd) == ChainMap
+        for key in keys:
+            assert key in newsd
+            torch.testing.assert_close(sd[key], as_loaded[key])
+
+
+def test_guess_numlayers():
+    model = models.get_model("llama", "micro")
+    sd = model.state_dict()
+    assert models._guess_num_layers(sd) == 5

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -14,13 +14,13 @@ def test_register():
 
 def test_getmodel():
     with pytest.raises(KeyError):
-        models.get_model("foo", "foo")
+        models._get_model_instance("foo", "foo")
     with pytest.raises(KeyError):
-        models.get_model("llama", "foo")
+        models._get_model_instance("llama", "foo")
     with pytest.raises(KeyError):
         models.list_variants("foo")
 
-    micro = models.get_model("llama", "micro")
+    micro = models._get_model_instance("llama", "micro")
     assert micro.config.nlayers == 5
 
 
@@ -30,12 +30,12 @@ def test_list():
 
 
 def test_load():
-    m = models.get_model("llama", "micro")
+    m = models._get_model_instance("llama", "micro")
     sd = m.state_dict()
 
     with tempfile.NamedTemporaryFile() as f:
         torch.save(sd, f.name)
-        loaded = models.load_model("llama", "micro", f.name)
+        loaded = models.get_model("llama", "micro", f.name)
 
         keys = loaded.state_dict().keys()
         first = next(iter(keys))
@@ -58,7 +58,7 @@ def test_load():
             path = Path(d) / f"{i}.pth"
             torch.save(dicts[i], path)
         newsd = serialization.load_state_dict(d)
-        as_loaded = models.load_model("llama", "micro", d).state_dict()
+        as_loaded = models.get_model("llama", "micro", d).state_dict()
         # this style load, layer-sharded, has to stitch together the state dicts.
         assert type(newsd) == ChainMap
         for key in keys:
@@ -67,6 +67,6 @@ def test_load():
 
 
 def test_guess_numlayers():
-    model = models.get_model("llama", "micro")
+    model = models._get_model_instance("llama", "micro")
     sd = model.state_dict()
     assert models._guess_num_layers(sd) == 5

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+from fms.utils import serialization
+
+
+def test_register():
+    with pytest.raises(KeyError):
+        serialization.register_adapter("llama", "meta", lambda x: x)
+
+
+def test_adapt():
+    t = torch.ones(5)
+    sd = {"feed_forward.w3": t}
+    adapted = serialization.get_adapted("llama", "meta", sd)
+
+    newkey = "ff_sub_layer.w1"
+    assert newkey in adapted
+    assert id(adapted[newkey]) == id(t)
+
+    adapted = serialization.get_adapted("foo", "foo", sd)
+    print(adapted.keys())
+    assert id(adapted["feed_forward.w3"]) == id(t)
+
+
+def test_list():
+    assert "meta" in serialization.list_sources("llama")
+
+
+def test_load():
+    with pytest.raises(ValueError):
+        serialization.load_state_dict("path", "fsdp", "tp")


### PR DESCRIPTION
As discussed internally, we want an API to load a model checkpoint based on a specified data source, data sharding format, and model distribution strategy in a general way, and where a variety of source formats can be added for any of the fms models.
