### PR TITLE
minor improvements to the tokenizer api

### DIFF
--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Union
+from typing import List, Optional, Union
 
 import torch
 import torch.nn.functional as F
@@ -25,7 +25,11 @@ class BaseTokenizer:
     cases where we'd like to write tests that don't depend on HF.
     """
 
-    def __init__(self, bos_id, eos_id):
+    def __init__(self, bos_id: int, eos_id: int):
+        """
+        bos_id: the ID representing the beginning-of-sentence token
+        eos_id: the ID representing the end-of-sentence token
+        """
         self.bos_token_id = bos_id
         self.eos_token_id = eos_id
 
@@ -127,7 +131,7 @@ class _HFTokenizer(BaseTokenizer):
         return self.tokenizer.get_vocab_size()
 
 
-def get_tokenizer(name: str, style=None) -> BaseTokenizer:
+def get_tokenizer(name: str, style: Optional[str] = None) -> BaseTokenizer:
     """
     Hack to get an instance of a tokenizer by name or path.
 

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -25,6 +25,10 @@ class BaseTokenizer:
     cases where we'd like to write tests that don't depend on HF.
     """
 
+    def __init__(self, bos_id, eos_id):
+        self.bos_token_id = bos_id
+        self.eos_token_id = eos_id
+
     def tokenize(self, text: str):
         raise NotImplementedError
 
@@ -48,7 +52,8 @@ class CharTokenizer(BaseTokenizer):
     """
 
     def __init__(self):
-        super().__init__()
+        # 2, 3 from ascii tables are "start of text" and "end of text"
+        super().__init__(2, 3)
 
     def tokenize(self, text: str):
         return list(text)
@@ -72,10 +77,10 @@ class _SentencePieceTokenizer(BaseTokenizer):
     """
 
     def __init__(self, path: str):
-        super().__init__()
         from sentencepiece import SentencePieceProcessor
 
         self.sp_model = SentencePieceProcessor(model_file=path)
+        super().__init__(self.sp_model.bos_id(), self.sp_model.eos_id())
 
     def tokenize(self, text: str):
         return self.sp_model.encode_as_pieces(text)
@@ -101,10 +106,10 @@ class _HFTokenizer(BaseTokenizer):
     """
 
     def __init__(self, name: str):
-        super().__init__()
         from transformers import AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(name)
+        super().__init__(self.tokenizer.bos_token_id, self.tokenizer.eos_token_id)
 
     def tokenize(self, text: str):
         return self.tokenizer.tokenize(text)
@@ -122,19 +127,26 @@ class _HFTokenizer(BaseTokenizer):
         return self.tokenizer.get_vocab_size()
 
 
-def get_tokenizer(name: str) -> BaseTokenizer:
+def get_tokenizer(name: str, style=None) -> BaseTokenizer:
     """
     Hack to get an instance of a tokenizer by name or path.
 
-    Tries to derive whether the name refers to a custom tokenizer, a
-    sentencepiece model file, or a HuggingFace tokenizer.
+    Args:
+
+    style: 'hf', 'sentencepiece', or 'fms'. If not specified, attempt to derive
+            the type based on the name.
     """
-    if name == "char_tokenizer":
+    if name == "char_tokenizer" and (style is None or style == "fms"):
         return CharTokenizer()
+
     # SentencePiece saves models as .model files.
     # It would be better to identify the type of the file accurately, e.g. using protobuf:
     # https://github.com/google/sentencepiece/issues/121
-    elif len(name) >= len(".model") and name[-len(".model") :] == ".model":
+    if style == "sentencepiece" or (
+        style is None
+        and len(name) >= len(".model")
+        and name[-len(".model") :] == ".model"
+    ):
         name = os.path.expanduser(name)
         if not os.path.exists(name):
             raise RuntimeError(f"Could not find SentencePiece model at '{name}'")
@@ -147,4 +159,9 @@ def get_tokenizer(name: str) -> BaseTokenizer:
         raise RuntimeError(
             f"Could not find tokenizer '{name}' and HuggingFace transformers is not installed"
         )
-    return _HFTokenizer(name)
+    if style is None or style == "hf":
+        return _HFTokenizer(name)
+    if style is None:
+        raise RuntimeError(f"Could not find a tokenzier {name}")
+    else:
+        raise RuntimeError(f"Could not find a {style} tokenizer with name {name}")

--- a/tests/utils/test_tokenizers.py
+++ b/tests/utils/test_tokenizers.py
@@ -1,4 +1,5 @@
 from fms.utils.tokenizers import get_tokenizer
+import pytest
 
 
 def test_hf_compat():
@@ -20,6 +21,17 @@ def test_hf_compat():
     assert fm_tokenizer.convert_tokens_to_string(
         ["hello", "world"]
     ) == hf_tokenizer.convert_tokens_to_string(["hello", "world"])
+    assert fm_tokenizer.bos_token_id == hf_tokenizer.bos_token_id
+    assert fm_tokenizer.eos_token_id == hf_tokenizer.eos_token_id
+
+
+def test_styled():
+    tokenizer_name = "EleutherAI/gpt-neox-20b"
+    get_tokenizer(tokenizer_name, style="hf")
+    with pytest.raises(RuntimeError):
+        get_tokenizer(tokenizer_name, style="fms")
+    with pytest.raises(RuntimeError):
+        get_tokenizer(tokenizer_name, style="sentencepiece")
 
 
 def test_char_tokenizer():
@@ -40,6 +52,8 @@ def test_char_tokenizer():
         111,
     ]
     assert char_tokenizer.convert_tokens_to_string(["h", "e", "l", "l", "o"]) == "hello"
+    assert char_tokenizer.bos_token_id == 2
+    assert char_tokenizer.eos_token_id == 3
 
 
 def test_out_of_range_ascii():


### PR DESCRIPTION
Added bos/eos tokens and explicit "style" lookup.

we use tokenizers from multiple sources in testing, and the bos/eos are tied to the tokenizer, so easier to write scripts where the tokenizer has an explicit bos/eos attached to it.
