### PR TITLE
Fix tie heads bug in HFAdaptedGPTBigCode found in transformers 4.35.0

### DIFF
--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest numpy
-        pip install transformers==4.34.1
+        pip install transformers==4.35.0
         pip install .
         
     - name: Test with pytest

--- a/fms/models/hf/gpt_bigcode/configuration_gpt_bigcode_hf.py
+++ b/fms/models/hf/gpt_bigcode/configuration_gpt_bigcode_hf.py
@@ -58,9 +58,7 @@ class HFAdaptedGPTBigCodeConfig(PretrainedConfig):
             is_decoder=is_decoder,
             # the default for this model is to tie_heads
             # so set to true if tie_word_embeddings is not given
-            tie_word_embeddings=kwargs.pop(
-                "tie_word_embeddings", True
-            ),
+            tie_word_embeddings=kwargs.pop("tie_word_embeddings", True),
             **kwargs,
         )
 

--- a/fms/models/hf/gpt_bigcode/configuration_gpt_bigcode_hf.py
+++ b/fms/models/hf/gpt_bigcode/configuration_gpt_bigcode_hf.py
@@ -56,8 +56,11 @@ class HFAdaptedGPTBigCodeConfig(PretrainedConfig):
             eos_token_id=eos_token_id,
             bos_token_id=bos_token_id,
             is_decoder=is_decoder,
-            tie_word_embeddings=kwargs.pop("tie_word_embeddings", False),
-            # note: This was added here as we handle tying of heads with our underlying model, we may want to revisit this in future
+            # the default for this model is to tie_heads
+            # so set to true if tie_word_embeddings is not given
+            tie_word_embeddings=kwargs.pop(
+                "tie_word_embeddings", True
+            ),
             **kwargs,
         )
 


### PR DESCRIPTION
HFAdaptedGPTBigCode was defaulting tie_word_embeddings=False even though the value in the underlying model was tie_heads=True. When creating from an FMS model, this is not an issue as the heads have already been tied, however if we do `from_pretrained`, this is not known and must fall back to tie_word_embeddings. 

Note: It is a little surprising this did not run into issue in transformers version 4.34.1 and lower (need to investigate that further). Having said that, this seems like the right thing to be doing as tie_word_embeddings=True should be the correct value for this model