### PR TITLE
save time in benchmarking script, doesn't need to load weights

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -242,9 +242,9 @@ def get_model(
 
     # post-init distribution
     if _is_dp(distributed_strategy):
-        model = _fsdp_wrap(model, distributed_strategy, local_rank, pre_load)
+        fms_model = _fsdp_wrap(fms_model, distributed_strategy, local_rank, pre_load)
 
-    if not pre_load:
+    if not pre_load and len(fms_sd):
         fms_model.load_state_dict(fms_sd, strict=False)
 
     return fms_model

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -1,33 +1,42 @@
 import argparse
 import os
 import statistics
-import time
 import timeit
 
 import torch
 from torch import distributed as dist
+from fms import models
 
-from fms.models.llama import load_fms_llama
 from fms.utils import generation, print0, tokenizers
 
 
 # Example running llama 7B on one A100:
 #
-# $ srun -N 1 --gres=gpu:1 torchrun --nproc_per_node=1 ./scripts/benchmark_inference.py --model_path=~/models/7B-F/ --tokenizer=~/models/tokenizer.model --batch_size=2 --seq_len=500
+# $ srun -N 1 --gres=gpu:1 torchrun --nproc_per_node=1 ./scripts/benchmark_inference.py --architecture=llama --variant=7b --tokenizer=~/models/tokenizer.model --batch_size=2 --seq_len=500
 # loading model
 # loading complete on rank 0
 # Uncompiled results:
-# - with use_cache=True, excluding first call
-#         35.20 ms per token
-# - without cache
-#         91.87 ms per token
+# - with use_cache=True
+#         34.86 ms per token
+# - with use_cache=False
+#         86.39 ms per token
+# End-to-end sequence generation
+# - with use_cache=True
+#         37.04 ms per token
+# - with use_cache=False
+#         90.68 ms per token
 # Compiling model...
-#
 # Compiled results:
-# - with use_cache=True, excluding first call
-#         21.31 ms per token
-# - without cache
-#         72.23 ms per token
+# - with use_cache=True
+#         18.66 ms per token
+# - with use_cache=False
+#         67.66 ms per token
+
+# (Compiled) End-to-end sequence generation
+# - with use_cache=True
+#         20.61 ms per token
+# - with use_cache=False
+#         71.45 ms per token
 
 
 parser = argparse.ArgumentParser(
@@ -35,10 +44,16 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument("--device_type", type=str, default="cuda")
 parser.add_argument(
-    "--model_path",
+    "--architecture",
     type=str,
-    required=True,
-    help="Path to the directory containing LLaMa weights (.pth files sharded by tensor parallel rank, not HF weights)",
+    default="llama",
+    help="The model architecture to benchmark",
+)
+parser.add_argument(
+    "--variant",
+    type=str,
+    default="7b",
+    help="The model variant (configuration) to benchmark. E.g. 7b, 13b, 70b.",
 )
 parser.add_argument(
     "--tokenizer",
@@ -77,7 +92,7 @@ if args.distributed:
     dist.init_process_group()
 
 print("loading model")
-model = load_fms_llama(args.model_path)
+model = models.get_model(args.architecture, args.variant)
 tokenizer = tokenizers.get_tokenizer(args.tokenizer)
 
 model.eval()

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -74,25 +74,20 @@ parser.add_argument(
     help="Batch size of mock input",
 )
 
-parser.add_argument(
-    "--distributed",
-    action="store_true",
-    help="This is a distributed job (multiple instances run with RANK+WORLD_SIZE)",
-)
-
 args = parser.parse_args()
 
 local_rank = int(os.getenv("LOCAL_RANK", 0))
+world_size = int(os.getenv("WORLD_SIZE", 1))
 device = torch.device(args.device_type, local_rank)
 
 torch.set_default_device(device)
 torch.set_default_dtype(torch.half)
 
-if args.distributed:
+if world_size > 1:
     dist.init_process_group()
 
 print("loading model")
-model = models.get_model(args.architecture, args.variant)
+model = models.get_model(args.architecture, args.variant, device_type=args.device_type)
 tokenizer = tokenizers.get_tokenizer(args.tokenizer)
 
 model.eval()


### PR DESCRIPTION
Make use of the 'get_model' API that fetches configurations of named models instead of relying on a file system path and full  load of all weights. This makes the benchmarking script run faster, we don't actually need to load the weights in order to benchmark.
