### PR TITLE
fixed default value for norm_eps as it was incorrect

### DIFF
--- a/fms/models/hf/llama/configuration_llama_hf.py
+++ b/fms/models/hf/llama/configuration_llama_hf.py
@@ -18,7 +18,7 @@ class HFAdaptedLLaMAConfig(PretrainedConfig):
         self,
         src_vocab_size: Optional[int] = 32000,
         emb_dim: Optional[int] = 4096,
-        norm_eps: float = 1e-6,
+        norm_eps: float = 1e-5,
         nheads: int = 32,
         kvheads: int = 0,
         nlayers: int = 32,

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -39,7 +39,7 @@ from fms.utils.tokenizers import _has_hf, get_tokenizer
 class LLaMAConfig(ModelConfig):
     src_vocab_size: int = 32_000  # can be set by tokenizer
     emb_dim: int = 4096
-    norm_eps: float = 1e-6
+    norm_eps: float = 1e-5
     nheads: int = 32
     kvheads: int = 0
     nlayers: int = 32


### PR DESCRIPTION
norm_eps in llama config was default to 1e-6, however it should have been 1e-5