### PR TITLE
wrapper utility method for wrapping an FMS model with a Huggingface API

### DIFF
--- a/fms/models/hf/__init__.py
+++ b/fms/models/hf/__init__.py
@@ -1,4 +1,4 @@
-from fms.models.hf.utils import wrap, register_fms_models
+from fms.models.hf.utils import to_hf_api, register_fms_models
 
 from fms.models.hf.gpt_bigcode import HFAdaptedGPTBigCodeForCausalLM
 from fms.models.hf.llama import HFAdaptedLLaMAForCausalLM

--- a/fms/models/hf/__init__.py
+++ b/fms/models/hf/__init__.py
@@ -1,1 +1,29 @@
 from fms.models.hf.utils import wrap, register_fms_models
+
+from fms.models.hf.gpt_bigcode import HFAdaptedGPTBigCodeForCausalLM
+from fms.models.hf.llama import HFAdaptedLLaMAForCausalLM
+from fms.models.gpt_bigcode import GPTBigCode, GPTBigCodeHeadless
+from fms.models.llama import LLaMA
+from fms.models.hf.gpt_bigcode.modeling_gpt_bigcode_hf import (
+    HFAdaptedGPTBigCodeHeadless,
+)
+from fms.models.hf.llama.modeling_llama_hf import HFAdaptedLLaMAHeadless
+
+"""
+mapping from an FMS model to its equivalent HF-Adapted model
+"""
+_fms_to_hf_adapt_map = {
+    LLaMA: HFAdaptedLLaMAForCausalLM,
+    GPTBigCode: HFAdaptedGPTBigCodeForCausalLM,
+    GPTBigCodeHeadless: HFAdaptedGPTBigCodeHeadless,
+}
+
+"""
+list of all headless base HF-Adapted models used in registration 
+"""
+_headless_models = [HFAdaptedGPTBigCodeHeadless, HFAdaptedLLaMAHeadless]
+
+"""
+list of all causal-lm HF-Adapted models used in registration 
+"""
+_causal_lm_models = [HFAdaptedGPTBigCodeForCausalLM, HFAdaptedLLaMAForCausalLM]

--- a/fms/models/hf/__init__.py
+++ b/fms/models/hf/__init__.py
@@ -1,0 +1,1 @@
+from fms.models.hf.utils import wrap, register_fms_models

--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -16,7 +16,7 @@ from transformers.modeling_outputs import (
 )
 from transformers.utils import ModelOutput, is_torch_fx_proxy
 
-from .utils import mask_2d_to_3d, mask_2d_to_3d_bidirectional
+from fms.models.hf.utils import mask_2d_to_3d, mask_2d_to_3d_bidirectional
 
 
 class _HFBase(PreTrainedModel):

--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -16,7 +16,7 @@ from transformers.modeling_outputs import (
 )
 from transformers.utils import ModelOutput, is_torch_fx_proxy
 
-from fms.models.hf.utils import mask_2d_to_3d, mask_2d_to_3d_bidirectional
+from .utils import mask_2d_to_3d, mask_2d_to_3d_bidirectional
 
 
 class _HFBase(PreTrainedModel):

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -93,7 +93,7 @@ def mask_2d_to_3d_bidirectional(
     return mask_encoder.unsqueeze(1) == mask_decoder.unsqueeze(2)
 
 
-def wrap(model: nn.Module, **override_config_kwargs) -> "HFModelArchitecture":
+def to_hf_api(model: nn.Module, **override_config_kwargs) -> "HFModelArchitecture":
     """Wrap an FMS model, converting its API to one of and Huggingface model
 
     Parameters

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -124,6 +124,8 @@ def wrap(model: nn.Module, **override_config_kwargs) -> "HFModelArchitecture":
     )
     from fms.models.hf.llama.modeling_llama_hf import HFAdaptedLLaMAForCausalLM
 
+    register_fms_models()
+
     __fms_to_hf_adapt_map = {
         "LLaMA": HFAdaptedLLaMAForCausalLM,
         "GPTBigCode": HFAdaptedGPTBigCodeForCausalLM,

--- a/fms/testing/_internal/hf/model_test_suite.py
+++ b/fms/testing/_internal/hf/model_test_suite.py
@@ -9,7 +9,7 @@ from fms.models.hf.modeling_hf_adapter import (
     HFEncoderDecoderModelArchitecture,
     HFDecoderModelArchitecture,
 )
-from fms.models.hf.utils import register_fms_models
+from fms.models.hf.utils import register_fms_models, wrap
 from fms.testing._internal.model_test_suite import ConfigFixtureMixin
 
 SEED = 42
@@ -231,9 +231,7 @@ class HFModelEquivalenceTestSuite(HFConfigFixtureMixin, HFModelFixtureMixin):
     def test_hf_and_fms_model_equivalence(self, fms_hf_model, model):
         """test model signature equivalence between huggingface model and fms model"""
 
-        _fms_hf_model = type(fms_hf_model).from_fms_model(
-            model, **fms_hf_model.config.to_dict()
-        )
+        _fms_hf_model = wrap(model, **fms_hf_model.config.to_dict())
         fms_signature_params = ModelSignatureParams(
             model, len(self._get_hf_signature_params) - 1
         )

--- a/fms/testing/_internal/hf/model_test_suite.py
+++ b/fms/testing/_internal/hf/model_test_suite.py
@@ -9,7 +9,7 @@ from fms.models.hf.modeling_hf_adapter import (
     HFEncoderDecoderModelArchitecture,
     HFDecoderModelArchitecture,
 )
-from fms.models.hf.utils import register_fms_models, wrap
+from fms.models.hf.utils import register_fms_models, to_hf_api
 from fms.testing._internal.model_test_suite import ConfigFixtureMixin
 
 SEED = 42
@@ -231,7 +231,7 @@ class HFModelEquivalenceTestSuite(HFConfigFixtureMixin, HFModelFixtureMixin):
     def test_hf_and_fms_model_equivalence(self, fms_hf_model, model):
         """test model signature equivalence between huggingface model and fms model"""
 
-        _fms_hf_model = wrap(model, **fms_hf_model.config.to_dict())
+        _fms_hf_model = to_hf_api(model, **fms_hf_model.config.to_dict())
         fms_signature_params = ModelSignatureParams(
             model, len(self._get_hf_signature_params) - 1
         )

--- a/tests/models/hf_equivalence/test_llama.py
+++ b/tests/models/hf_equivalence/test_llama.py
@@ -9,7 +9,7 @@ from fms.testing.comparison import (
     HFModelSignatureParams,
     ModelSignatureParams,
 )
-from fms.models.hf.utils import wrap
+from fms.models.hf.utils import to_hf_api
 
 
 @pytest.mark.slow
@@ -26,7 +26,7 @@ def test_llama_7b_equivalence():
     # convert the hf model to fms
     model = get_model("llama", "7b", llama_model_path, "hf")
 
-    hf_model_fms = wrap(
+    hf_model_fms = to_hf_api(
         model,
         bos_token_id=hf_model.config.bos_token_id,
         eos_token_id=hf_model.config.eos_token_id,

--- a/tests/models/hf_equivalence/test_llama.py
+++ b/tests/models/hf_equivalence/test_llama.py
@@ -1,6 +1,5 @@
 import pytest
 
-from fms.models.hf.llama.modeling_llama_hf import HFAdaptedLLaMAForCausalLM
 from fms.models.llama import convert_hf_llama
 import torch
 
@@ -9,6 +8,7 @@ from fms.testing.comparison import (
     HFModelSignatureParams,
     ModelSignatureParams,
 )
+from fms.models.hf.utils import wrap
 
 
 @pytest.mark.slow
@@ -25,7 +25,7 @@ def test_llama_7b_equivalence():
     # convert the hf model to fms
     model = convert_hf_llama(hf_model)
 
-    hf_model_fms = HFAdaptedLLaMAForCausalLM.from_fms_model(
+    hf_model_fms = wrap(
         model,
         bos_token_id=hf_model.config.bos_token_id,
         eos_token_id=hf_model.config.eos_token_id,


### PR DESCRIPTION
Currently, in order to get the HF adapted FMS model variant, one would need to know the model type and call the appropriate `model_class.from_fms_model` method. This was somewhat cumbersome and was not great for writing generic script writing as you would need to provide logic to decide what model to create. This PR introduces a new `wrap` method which will determine the type of FMS model and provide the proper wrapping.

before:

```python
# this gets you the fms model
model = get_model("llama", "7b", model_path=model_path, source="hf", device_type="cuda")

# this gets you the hf adapted fms model
model = HFAdaptedLLaMAForCausalLM.from_fms_model(model)
```

after

```python
# this gets you the fms model
model = get_model("llama", "7b", model_path=model_path, source="hf", device_type="cuda")

# this gets you the hf adapted fms model
model = wrap(model)
```