### PR TITLE
Updated modeling_llama_hf.py so that generate works in multi GPU envi…

### DIFF
--- a/fms/models/hf/llama/modeling_llama_hf.py
+++ b/fms/models/hf/llama/modeling_llama_hf.py
@@ -92,7 +92,9 @@ class HFAdaptedLLaMAHeadless(HFDecoderModelArchitecture):
         # Add more cached rope freqs if over cached number
         max_expected_len = input_ids.shape[1] + torch.max(position_ids)
         if max_expected_len > self.decoder.model.rot_emb.max_seq_len:
-            self.decoder.model.rot_emb.compute_freqs_cis(input_ids.device, max_expected_len)
+            self.decoder.model.rot_emb.compute_freqs_cis(
+                input_ids.device, max_expected_len
+            )
 
         return {
             "input_ids": input_ids,


### PR DESCRIPTION
…ronments

Describe the bug

When calling generate on HFAdaptedLLaMA, an exception is raised due to compute_freqs_cis not being called with all parameters (device is being left out which will result in issues on multiple ranks)

To Reproduce
Steps to reproduce the behavior:

Use a multi-gpu environment
create an HFAdaptedLLaMA model with some max sequence length generate past the max sequence length
Expected behavior

There should be no errors and generate should finish

Environment (please complete the following information):

multiple gpus are required