### PR TITLE
simple batch generation

### DIFF
--- a/fms/distributed/strategy.py
+++ b/fms/distributed/strategy.py
@@ -77,7 +77,7 @@ class UniformModelParallelStrategy(DistributedStrategy):
         num_dev = len(devices)
         layers_per_dev = num_layers // num_dev
         remainder = num_layers - (layers_per_dev * num_dev)
-        self.layer_to_device = [0] * len(devices)
+        self.layer_to_device = [0] * num_layers
         layer_id = 0
         for dev_idx in range(len(devices)):
             for i in range(layers_per_dev):

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, MutableMapping, Union, Optional
+from typing import Any, Callable, List, MutableMapping, Optional, Union
 
 import torch
 import torch.nn.functional as F

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -72,7 +72,19 @@ def generate(
         max_length = max(p.size(0) for p in input_ids)
         requires_padding = any(p.size(0) < max_length for p in input_ids)
         if requires_padding:
-            input_ids = [torch.cat((torch.tensor([pad_id] * (max_length - p.size(0)), device=p.device, dtype=torch.long), p)) for p in input_ids]
+            input_ids = [
+                torch.cat(
+                    (
+                        torch.tensor(
+                            [pad_id] * (max_length - p.size(0)),
+                            device=p.device,
+                            dtype=torch.long,
+                        ),
+                        p,
+                    )
+                )
+                for p in input_ids
+            ]
         input_ids = torch.stack(input_ids, dim=0)
         batched = True
     else:

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -125,7 +125,6 @@ def generate(
             the pad token id to use in case of batch generation where sequences are of different lengths
     """
     batched = False
-    requires_padding = False
     if num_beams != 1:
         raise NotImplementedError("generate() does yet not support beam search")
     if isinstance(input_ids, torch.Tensor):
@@ -137,6 +136,8 @@ def generate(
         requires_padding = any(p.size(0) < max_length for p in input_ids)
         if requires_padding:
             input_ids = [left_pad(p, max_length, pad_id) for p in input_ids]
+        else:
+            pad_id = -1
         input_ids = torch.stack(input_ids, dim=0)
         batched = True
     else:
@@ -150,9 +151,6 @@ def generate(
     kwargs: MutableMapping[str, Any] = dict()
     kwargs["past_key_value_states"] = None
     kwargs["use_cache"] = use_cache
-
-    if not requires_padding:
-        pad_id = -1
 
     for i in range(max_new_tokens):
         input_ids = next_input[:, -max_seq_len:]

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -19,6 +19,7 @@ def _make_cache_contiguous(past_key_value_states):
             # torch._dynamo.mark_dynamic(n_kv_s[layer_idx][tensor_idx], 2)
     return n_kv_s
 
+
 def left_pad(input_ids: torch.Tensor, max_length: int, pad_id: int = 0) -> torch.Tensor:
     """
     left pad an input_ids tensor
@@ -44,7 +45,10 @@ def left_pad(input_ids: torch.Tensor, max_length: int, pad_id: int = 0) -> torch
     )
     return torch.cat((pads_tensor, input_ids))
 
-def __create_attention_mask(input_ids: torch.Tensor, use_cache: bool, is_prompt: bool, pad_id: int = -1) -> Optional[torch.Tensor]:
+
+def __create_attention_mask(
+    input_ids: torch.Tensor, use_cache: bool, is_prompt: bool, pad_id: int = -1
+) -> Optional[torch.Tensor]:
     """
     Optionally create an attention mask if one is required
 
@@ -155,10 +159,7 @@ def generate(
 
         # create the attention mask
         kwargs["mask"] = __create_attention_mask(
-            input_ids=result,
-            use_cache=use_cache,
-            is_prompt=i == 0,
-            pad_id=pad_id
+            input_ids=result, use_cache=use_cache, is_prompt=i == 0, pad_id=pad_id
         )
 
         output = model(input_ids, **kwargs)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -40,10 +40,9 @@ parser.add_argument(
     help="Path to the directory containing LLaMa weights (.pth files sharded by tensor parallel rank, not HF weights)",
 )
 parser.add_argument(
-    "--model_path_source",
+    "--model_source",
     type=str,
-    default="meta",
-    help="The source format of the model weights. E.g. meta, hf",
+    help="Source of the checkpoint. E.g. 'meta', 'hf', None",
 )
 parser.add_argument(
     "--checkpoint_sharding",

--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -76,12 +76,16 @@ def test_batched():
     )
     assert result == "ABCDEFGHIJ"
 
+
 def test_batched_jagged():
     _model_mock = ModelMock()
     tokenizer = get_tokenizer("char_tokenizer")
     prompts = ["ABCDE", "ABCDEFGH"]
 
-    ids_batch = [torch.tensor(tokenizer.convert_tokens_to_ids(tokenizer.tokenize(prompt))) for prompt in prompts]
+    ids_batch = [
+        torch.tensor(tokenizer.convert_tokens_to_ids(tokenizer.tokenize(prompt)))
+        for prompt in prompts
+    ]
     batch_result = generate(_model_mock, ids_batch, max_new_tokens=5, do_sample=False)
     prompt1_batch_result_str = tokenizer.convert_tokens_to_string(
         tokenizer.convert_ids_to_tokens(batch_result[0])
@@ -92,8 +96,12 @@ def test_batched_jagged():
     assert prompt1_batch_result_str == "\x00\x00\x00ABCDEFGHIJ"
     assert prompt2_batch_result_str == "ABCDEFGHIJKLM"
 
-    prompt1_standalone_result = generate(_model_mock, ids_batch[0], max_new_tokens=5, do_sample=False)
-    prompt2_standalone_result = generate(_model_mock, ids_batch[1], max_new_tokens=5, do_sample=False)
+    prompt1_standalone_result = generate(
+        _model_mock, ids_batch[0], max_new_tokens=5, do_sample=False
+    )
+    prompt2_standalone_result = generate(
+        _model_mock, ids_batch[1], max_new_tokens=5, do_sample=False
+    )
     prompt1_standalone_result_str = tokenizer.convert_tokens_to_string(
         tokenizer.convert_ids_to_tokens(prompt1_standalone_result)
     )
@@ -101,8 +109,9 @@ def test_batched_jagged():
         tokenizer.convert_ids_to_tokens(prompt2_standalone_result)
     )
 
-    assert prompt1_standalone_result_str == prompt1_batch_result_str.replace("\x00","")
+    assert prompt1_standalone_result_str == prompt1_batch_result_str.replace("\x00", "")
     assert prompt2_standalone_result_str == prompt2_batch_result_str
+
 
 def test_truncate():
     result = torch.ones(20)


### PR DESCRIPTION
Currently, the generate utility function does not work properly with batches, this PR addresses that issue.

For the generate function:

- input_ids can now be a list of tensors. If input ids is a list, it is assumed to be a batch
- pad_id is defaulted to 0, and will be used in the case of batch generation when sequences are of different lengths