### PR TITLE
Add a base dataset class that loads arrow files

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -25,6 +25,7 @@ jobs:
         pip install transformers==4.35.0
         pip install types-requests
         pip install mypy
+        pip install pyarrow-stubs==10.0.1.7
         pip install .
         
     - name: Test with pytest

--- a/fms/datasets/__init__.py
+++ b/fms/datasets/__init__.py
@@ -1,8 +1,11 @@
-from torch.utils.data import Dataset, IterableDataset
 from typing import Callable, Mapping
-from fms.datasets.instructions import JsonInstructions
+
+from torch.utils.data import Dataset, IterableDataset
+
 from fms.datasets import text
+from fms.datasets.instructions import JsonInstructions
 from fms.utils.tokenizers import BaseTokenizer
+
 
 __dataset_factory: Mapping[str, Callable[[str, BaseTokenizer], Dataset] | type] = {
     "instruction": JsonInstructions,
@@ -36,7 +39,9 @@ def _state_dict_save_helper(target):
             continue
 
         if isinstance(dict_attrs[attr], DatasetStateDictMixin):
-            result[attr] = dict_attrs[attr].state_dict()
+            sub_dict = dict_attrs[attr].state_dict()
+            for sub_attr in sub_dict:
+                result[f"{attr}.{sub_attr}"] = sub_dict[sub_attr]
         # We don't serialize any dataset that doesn't have this mixin.
         elif isinstance(dict_attrs[attr], Dataset):
             raise TypeError(
@@ -63,9 +68,9 @@ def _state_dict_load_helper(target, state_dict):
         if "." in attr:
             attr_name, sub_attr = attr.split(".", 1)
             sub_dict = {sub_attr: state_dict[attr]}
-            if isinstance(dict_attrs[attr], DatasetStateDictMixin):
+            if isinstance(dict_attrs[attr_name], DatasetStateDictMixin):
                 # Make sure we use any overriden load_state_dict in nested datasets
-                dict_attrs[attr].load_state_dict(sub_dict)
+                dict_attrs[attr_name].load_state_dict(sub_dict)
             else:
                 _state_dict_load_helper(dict_attrs[attr_name], sub_dict)
         elif attr not in dict_attrs:
@@ -98,9 +103,9 @@ class DatasetStateDictMixin:
         return _state_dict_save_helper(self)
 
     # In cases where the instance of DataPipeStateDictMixin composes another
-    # DataPipe, an explicit implementation of this function will be needed.
+    # DataSet, an explicit implementation of this function will be needed.
     # This default implementation doesn't know the type of the serialized
-    # datapipe, so can't construct it.
+    # dataset, so can't construct it.
     def load_state_dict(self, state_dict):
         _state_dict_load_helper(self, state_dict)
 

--- a/fms/datasets/arrow.py
+++ b/fms/datasets/arrow.py
@@ -1,0 +1,107 @@
+import sys
+from collections import UserDict
+
+import pyarrow as pa
+import urllib3
+from pyarrow.fs import FileSystem, FileType, LocalFileSystem, S3FileSystem
+from torch.utils.data import Dataset, IterableDataset
+
+from fms.datasets import DatasetStateDictMixin
+
+
+class _ArrowFileData(UserDict):
+    def __init__(self, fs: FileSystem, path: str):
+        self.fs = fs
+        self.path = path
+
+    def __getitem__(self, idx: int):
+        with self.fs.open_input_file(self.path) as file:
+            reader = pa.ipc.open_file(file)
+            print(self.path, file, idx)
+            return reader.get_batch(idx)
+
+    def __iter__(self):
+        with self.fs.open_input_file(self.path) as file:
+            reader = pa.ipc.open_file(file)
+            for i in range(reader.num_record_batches):
+                yield reader.get_batch(i)
+
+    def __len__(self):
+        with self.fs.open_input_file(self.path) as file:
+            reader = pa.ipc.open_file(file)
+            return reader.num_record_batches
+
+
+class ArrowFilesDataset(IterableDataset, DatasetStateDictMixin):
+    """
+    Creates a dataset from a path to a directory of arrow files, either in
+    S3/COS or a local file system.
+
+    uri: s3://endpoint_host/path/to/files or file:///path/to/files
+    step: for distributed training, use rank+1
+    start_idx: for re-starting training, pick up where left off
+    """
+
+    def __init__(self, uri: str, start_idx: int = 0, step: int = 1):
+        self.uri = uri
+        self.start_idx = start_idx
+        self.step = step
+        self._initialize()
+
+    def load_state_dict(self, state_dict):
+        super().load_state_dict(state_dict)
+        self._initialize()
+
+    def _initialize(self):
+        url = urllib3.util.parse_url(self.uri)
+        path = url.path
+        file_system = None
+        if url.scheme == "file":
+            file_system = LocalFileSystem()
+        elif url.scheme == "s3":
+            if url.host is not None:
+                endpoint = "https://" + url.host
+                file_system = S3FileSystem(endpoint_override=endpoint)
+            else:
+                file_system = S3FileSystem()
+            if path[0] == "/":
+                path = path[1:]
+        else:
+            raise ValueError(f"Unsupported scheme {url.scheme}")
+
+        files = file_system.get_file_info(pa.fs.FileSelector(path))
+        files = [
+            _ArrowFileData(file_system, f.path)
+            for f in files
+            if f.type != FileType.Directory
+        ]
+
+        self._files = files
+        self.length = sum([len(f) for f in files])
+
+        file_offset = self.start_idx
+        while file_offset > len(self._files[0]):
+            file_offset -= len(self._files[0])
+            self._files = self._files[1:]
+        self.file_offset = file_offset
+        self.file_offset += self.step
+
+    def __iter__(self):
+        for file in self._files:
+            remainder = (len(file) - self.file_offset) % self.step
+            remainder = self.step - remainder
+            for i in range(self.file_offset, len(file), self.step):
+                self.start_idx += self.step
+                yield file[i]
+            self.file_offset = remainder
+
+
+if __name__ == "__main__":
+    if not len(sys.argv) == 2:
+        print("Usage: python -m fms.datasets.arrow <path>")
+        sys.exit(1)
+    ds = ArrowFilesDataset(sys.argv[1])
+    for i, batch in enumerate(ds):
+        print(i, batch)
+        if i > 20:
+            break


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #140
* __->__ #139
* #138

I'm hesitant to add mock data generators that would be required for unit testing this class. I suspect if we write 'composable' datasets and keep the actual data loading pretty isolated from any other logic (packing, shuffling, sharding) we can test the specific functionality of composing datasets separately. If we do add mock datasets, they won't cover the s3 path, which is the majority of what this class does.

I did test manually of course, and it would be pretty easy to add the code to generate mock datasets if we think it's necessary.