### PR TITLE
Small improvement to the example inference script

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -3,10 +3,10 @@ import itertools
 import os
 
 import torch
+import torch._inductor.config
 from torch import distributed as dist
 
-from fms.distributed.strategy import TensorParallelStrategy
-from fms.models.llama import load_fms_llama
+from fms.models import get_model
 from fms.utils import generation, tokenizers
 from fms.utils.generation import generate
 
@@ -18,13 +18,31 @@ from fms.utils.generation import generate
 # Example usage of 13B model on 2 GPUs with Tensor Parallel:
 # srun -N 1 --gres=gpu:2 torchrun --nproc_per_node=2 scripts/inference.py --model_path=~/models/13B-F --tokenizer=~/models/tokenizer.model --distributed
 
-parser = argparse.ArgumentParser(description="Script to run inference on a LLaMA model")
+parser = argparse.ArgumentParser(
+    description="Script to run inference on a causal model"
+)
 parser.add_argument("--device_type", type=str, default="cuda")
+parser.add_argument(
+    "--architecture",
+    type=str,
+    default="llama",
+    help="The model architecture to benchmark",
+)
+parser.add_argument(
+    "--variant",
+    type=str,
+    default="7b",
+    help="The model variant (configuration) to benchmark. E.g. 7b, 13b, 70b.",
+)
 parser.add_argument(
     "--model_path",
     type=str,
-    required=True,
     help="Path to the directory containing LLaMa weights (.pth files sharded by tensor parallel rank, not HF weights)",
+)
+parser.add_argument(
+    "--model_source",
+    type=str,
+    help="Source of the checkpoint. E.g. 'meta', 'hf', None",
 )
 parser.add_argument(
     "--tokenizer",
@@ -64,7 +82,11 @@ parser.add_argument("--context_file", type=str, default=None, help="File to summ
 args = parser.parse_args()
 
 local_rank = int(os.getenv("LOCAL_RANK", 0))
-device = torch.device(args.device_type, local_rank)
+world_size = int(os.getenv("WORLD_SIZE", 1))
+if args.device_type == "cuda":
+    device = torch.device(args.device_type, local_rank)
+else:
+    device = torch.device(args.device_type)
 
 torch.set_default_device(device)
 torch.set_default_dtype(torch.half)
@@ -77,7 +99,23 @@ if args.distributed:
     dist.init_process_group()
 
 print("loading model")
-model = load_fms_llama(args.model_path)
+if args.distributed:
+    distr_param = "tp"
+else:
+    if torch.cuda.device_count() > 1 and world_size == 1:
+        distr_param = "mp"
+    else:
+        distr_param = None
+
+model = get_model(
+    args.architecture,
+    args.variant,
+    model_path=args.model_path,
+    device_type=args.device_type,
+    source=args.model_source,
+    distributed_strategy=distr_param,
+    group=dist.group.WORLD,
+)
 tokenizer = tokenizers.get_tokenizer(args.tokenizer)
 model.eval()
 torch.set_grad_enabled(False)


### PR DESCRIPTION
This PR adds the usage of `get_model` to the inference script, as well as some args for it so more models can be used in the script. If ghstack was working, this would be the first of 3.