### PR TITLE
Add positive and negative feedback to slash commands

### DIFF
--- a/.github/workflows/ghstack_land.yaml
+++ b/.github/workflows/ghstack_land.yaml
@@ -19,6 +19,9 @@
 #
 # The PRs are merged by a bot account "fms-cibot" which has push
 # permissions on the repo.
+#
+# When a land is executed successfully, the horray emoji is added
+# When a land execution fails, a comment is added with a link to the logs
 
 name: Land ghstack PRs
 on:
@@ -69,3 +72,29 @@ jobs:
         ghstack land "${{ github.event.client_payload.pull_request.html_url }}"
       env:
         GITHUB_TOKEN: ${{ secrets.LAND_TOKEN }}
+
+    - name: Create URL to the run output
+      if: ${{ failure() }}
+      id: vars
+      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+    - name: Create comment
+      if: ${{ failure() }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        token: ${{ secrets.LAND_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: |
+          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+
+    - name: Add reaction
+      if: ${{ success() }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        token: ${{ secrets.LAND_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reaction-type: hooray

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -14,6 +14,10 @@
 # Supported commands:
 # - /land: invokes the land-command workflow, to land (merge) PRs
 #          stacked through ghstack
+#
+# When a command is recognised, the rocket and eyes emojis are added
+# When a command is executed successfully, the horray emoji is added
+# When a command execution fails, a comment is added with a link to the logs
 
 name: Slash Command Routing
 on:
@@ -33,3 +37,29 @@ jobs:
         permission: write
         commands: |
           land
+
+    - name: Create URL to the run output
+      if: ${{ failure() }}
+      id: vars
+      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+  
+    - name: Create comment
+      if: ${{ failure() }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        token: ${{ secrets.LAND_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: |
+          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+
+    - name: Add reaction
+      if: ${{ success() }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        token: ${{ secrets.LAND_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reaction-type: hooray

--- a/.github/workflows/slash.yml
+++ b/.github/workflows/slash.yml
@@ -16,8 +16,6 @@
 #          stacked through ghstack
 #
 # When a command is recognised, the rocket and eyes emojis are added
-# When a command is executed successfully, the horray emoji is added
-# When a command execution fails, a comment is added with a link to the logs
 
 name: Slash Command Routing
 on:
@@ -37,29 +35,3 @@ jobs:
         permission: write
         commands: |
           land
-
-    - name: Create URL to the run output
-      if: ${{ failure() }}
-      id: vars
-      run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
-  
-    - name: Create comment
-      if: ${{ failure() }}
-      uses: peter-evans/create-or-update-comment@v2
-      with:
-        token: ${{ secrets.LAND_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-        body: |
-          Something went wrong with your `/${{ github.event.client_payload.slash_command.command }}` command: [please check the logs][1].
-
-          [1]: ${{ steps.vars.outputs.run-url }}
-
-    - name: Add reaction
-      if: ${{ success() }}
-      uses: peter-evans/create-or-update-comment@v2
-      with:
-        token: ${{ secrets.LAND_TOKEN }}
-        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-        reaction-type: hooray


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #148
* __->__ #147

Add an horray emoji as reaction to a slash command comment to imply
success. Add a comment with a link to the logs in case of failure.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>