### PR TITLE
Fix linter CI failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: "--check --verbose"
+          options: "--check --verbose --diff"
           src: "."
           version: ">= 23.3.0"
       - uses: isort/isort-action@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --diff"
+          options: "--check --diff --color"
           src: "."
           version: ">= 23.3.0"
       - uses: isort/isort-action@master

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -16,7 +16,7 @@ class GPTBigCodeConfig(ModelConfig):
     # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
     src_vocab_size: int = 49157
     # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
-    emb_dim: int = 2048 
+    emb_dim: int = 2048
     nheads: int = 12
     nlayers: int = 12
     pad_id: int = 0

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -13,8 +13,12 @@ from fms.utils.config import ModelConfig
 
 @dataclass
 class GPTBigCodeConfig(ModelConfig):
-    src_vocab_size: int = 49157  # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
-    emb_dim: int = 2048  # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
+    src_vocab_size: int = (
+        49157  # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
+    )
+    emb_dim: int = (
+        2048  # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
+    )
     nheads: int = 12
     nlayers: int = 12
     pad_id: int = 0

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -13,12 +13,10 @@ from fms.utils.config import ModelConfig
 
 @dataclass
 class GPTBigCodeConfig(ModelConfig):
-    src_vocab_size: int = (
-        49157  # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
-    )
-    emb_dim: int = (
-        2048  # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
-    )
+    # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
+    src_vocab_size: int = 49157
+    # This param default is based on https://huggingface.co/bigcode/gpt_bigcode-santacoder
+    emb_dim: int = 2048 
     nheads: int = 12
     nlayers: int = 12
     pad_id: int = 0

--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -1678,9 +1678,11 @@ class HFEncoderDecoderModelArchitecture(
             decoder_attention_mask,
             hf_dec_attention_mask,
         ) = self._compute_decoder_attention_masks(
-            decoder_input_ids
-            if decoder_input_ids is not None
-            else decoder_inputs_embeds,
+            (
+                decoder_input_ids
+                if decoder_input_ids is not None
+                else decoder_inputs_embeds
+            ),
             decoder_attention_mask,
             is_cache_used_and_filled,
             inference=use_cache is not None,
@@ -1731,13 +1733,17 @@ class HFEncoderDecoderModelArchitecture(
             input_ids=decoder_input_ids,
             encoder_outputs=encoder_outputs,
             encoder_hidden_states=enc_hidden_state,
-            encoder_attention_mask=hf_attention_mask
-            if attention_mask is not None and self.decoder._attention_mask_dim == 2
-            else attention_mask,
-            attention_mask=hf_dec_attention_mask
-            if decoder_attention_mask is not None
-            and self.decoder._attention_mask_dim == 2
-            else decoder_attention_mask,
+            encoder_attention_mask=(
+                hf_attention_mask
+                if attention_mask is not None and self.decoder._attention_mask_dim == 2
+                else attention_mask
+            ),
+            attention_mask=(
+                hf_dec_attention_mask
+                if decoder_attention_mask is not None
+                and self.decoder._attention_mask_dim == 2
+                else decoder_attention_mask
+            ),
             inputs_embeds=decoder_inputs_embeds,
             past_key_values=past_key_values,
             use_cache=use_cache,

--- a/tests/models/hf/test_llama_hf.py
+++ b/tests/models/hf/test_llama_hf.py
@@ -56,9 +56,9 @@ class LLaMA2HFFixtures(ModelFixtureMixin, HFConfigFixtureMixin, HFModelFixtureMi
                 hidden_size=hf_config.hidden_size,
                 rms_norm_eps=hf_config.norm_eps,
                 num_attention_heads=hf_config.nheads,
-                num_key_value_heads=None
-                if hf_config.kvheads == 0
-                else hf_config.kvheads,
+                num_key_value_heads=(
+                    None if hf_config.kvheads == 0 else hf_config.kvheads
+                ),
                 num_hidden_layers=hf_config.nlayers,
                 pad_token_id=hf_config.pad_token_id,
                 intermediate_size=int(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #158

Fix linter CI failures that popped up in CI.
Add the --diff --color options to the black lineter to
help fix linter failures in the future.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>