### PR TITLE
Pin the version of black

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           options: "--check --diff --color"
           src: "."
-          version: ">= 23.3.0"
+          version: "~= 23.3.0"
       - uses: isort/isort-action@master
         with:
           sort-paths: fms


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #159

Pin the version of black, the python linter, to avoid pulling in
new versions that might break CI.

Use the compatibility operator =~ which means new non-breaking
patch versions are allowed, for instance 23.3.1 is allowed but
23.4.x or 24.x are not.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>