### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ llama_generator = pipeline(task="text-generation", model=llama_hf, tokenizer=tok
 llama_generator("""q: how are you? a: I am good. How about you? q: What is the weather like today? a:""")
 ```
 
-A detailed example is provided [here](./notebooks/hf_adapted_llama_inference.ipynb).
+A detailed example is provided [here](./notebooks/hf_adapted_inference.ipynb).
 
 ## Tuning
 


### PR DESCRIPTION
The current link to the HF Model Support example is incorrect and gives file not found error.

Broken link `A detailed example is provided` [here](https://github.com/foundation-model-stack/foundation-model-stack/blob/main/notebooks/hf_adapted_llama_inference.ipynb) in the [ReadMe](https://github.com/foundation-model-stack/foundation-model-stack?tab=readme-ov-file#hf-model-support)