### PR TITLE
Add py.typed to the package

### DIFF
--- a/fms/py.typed
+++ b/fms/py.typed
@@ -1,0 +1,5 @@
+# Marker file for PEP 561. 
+# The ibm-fms package uses inline types.
+
+# Inline types are only partially implemented in the fms.models.hf package
+partial

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
     ],
+    package_data={"ibm-fms": ["py.typed"]},
 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #170

Add a py.typed marker file for PEP 561.
This indicates to consumers of this package that
the ibm-fms package uses inline types.

py.typed includes the string "partial" to indicate
that inline types are only partially implemented,
specifically in the fms.models.hf package.

Update setup.py to include py.typed when building
the ibm-fms package.

This change will allow consumers like fms-extra
to run mypy checks on code that import fms.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>