### PR TITLE
Cache python dependencies in workflows

### DIFF
--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -13,21 +13,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
+      id: setup_python
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Restore Virtualenv
+      uses: actions/cache/restore@v4
+      id: cache-venv-restore
+      with:
+        path: ./.venv/
+        key: ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-${{ hashFiles('*requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest numpy
-        pip install transformers==4.35.0
-        pip install safetensors
-        pip install pyarrow
-        pip install lm_eval
-        pip install .
+        pip install -r test-requirements.txt
         
     - name: Test with pytest
       run: |
         pytest -vv -rP tests/
+
+    - name: Save Virtualenv
+      id: cache-venv-save
+      uses: actions/cache/save@v4
+      with:
+        path: ./.venv/
+        key: ${{ steps.cache-venv-restore.outputs.cache-primary-key }}

--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -39,6 +39,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
         
+        # Enables the virtual env for following steps
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+
     - name: Test with pytest
       run: |
         pytest -vv -rP tests/

--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -29,6 +29,13 @@ jobs:
           ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
     - name: Install dependencies
       run: |
+        # Create the virtual environment
+        python -m venv .venv
+        . ./.venv/bin/activate
+
+        # Install the dependencies
+        # In case of a cache hit on the primary key, this will be a no-op
+        # In case of a cache miss, but hit on a secondary key, this will update what's changed
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
         

--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -45,6 +45,9 @@ jobs:
 
     - name: Test with pytest
       run: |
+        # Install fms from the PR, all dependencies are already
+        # installed in the virtual env
+        pip install .
         pytest -vv -rP tests/
 
     - name: Save Virtualenv

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,23 +13,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
+      id: setup_python
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Restore Virtualenv
+      uses: actions/cache/restore@v4
+      id: cache-venv-restore
+      with:
+        path: ./.venv/
+        key: ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-${{ hashFiles('*requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest numpy
-        pip install transformers==4.35.0
-        pip install types-requests
-        pip install mypy
-        pip install pyarrow-stubs==10.0.1.7
-        pip install safetensors
-        pip install .
+        pip install -r test-requirements.txt
         
     - name: Test with pytest
       run: |
         mypy --exclude hf --exclude testing fms
 
+    - name: Save Virtualenv
+      id: cache-venv-save
+      uses: actions/cache/save@v4
+      with:
+        path: ./.venv/
+        key: ${{ steps.cache-venv-restore.outputs.cache-primary-key }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -29,9 +29,16 @@ jobs:
           ${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-venv-
     - name: Install dependencies
       run: |
+        # Create the virtual environment
+        python -m venv .venv
+        . ./.venv/bin/activate
+
+        # Install the dependencies
+        # In case of a cache hit on the primary key, this will be a no-op
+        # In case of a cache miss, but hit on a secondary key, this will update what's changed
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
-        
+
     - name: Test with pytest
       run: |
         mypy --exclude hf --exclude testing fms

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -39,6 +39,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r test-requirements.txt
 
+        # Enables the virtual env for following steps
+        echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+        echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+
     - name: Test with pytest
       run: |
         mypy --exclude hf --exclude testing fms

--- a/hf-requirements.txt
+++ b/hf-requirements.txt
@@ -1,0 +1,7 @@
+# Used to install pinned dependencies
+# Useful for dev/test jobs caches
+# Must be kept in sync with setup.py
+
+-r requirements.txt
+
+transformers==4.35.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Used to install pinned dependencies
+# Useful for dev/test jobs caches
+# Must be kept in sync with setup.py
+torch == 2.2.0 # This is what is installed in CI today

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,16 @@
+# Used to install pinned test dependencies
+# Useful for dev/test jobs caches
+
+-r hf-requirements.txt
+
+# Test tools
+mypy==1.8.0
+mypy-extensions==1.0.0
+pytest==8.0.0
+
+# Types packages
+pyarrow-stubs==10.0.1.7
+types-requests==2.31.0.20240125
+
+# Model testing
+lm_eval==0.4.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #174

The fms-testing and mypy CI job install FMS dependencies and test
dependencies for every CI job, which is time and resource consuming.

Start caching the python virtualenv using GitHub caches. Introduce
requirement files with pinned dependencies which are then used
as keys to distinguish cache hits or miss.

Rather than caching the pip cache, we cache the entire virtualenv
as that further saves the installation time.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>