### PR TITLE
training bugfix and prep for init changes

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -259,6 +259,7 @@ def get_model(
     else:
         initial_device = device
 
+    lazy_sd: MutableMapping[str, Any] = {}
     if model_path is not None:
         lazy_sd = serialization.load_state_dict(
             model_path,
@@ -313,6 +314,8 @@ def get_model(
             local_rank,
             world_size,
         )
+    elif hasattr(fms_model, 'reset_parameters'):
+        fms_model.reset_parameters()
 
     if pre_load:
         fms_model = model_wrap(fms_model)

--- a/scripts/train_causal.py
+++ b/scripts/train_causal.py
@@ -36,7 +36,7 @@ parser.add_argument(
 parser.add_argument(
     "--variant",
     type=str,
-    default="7b",
+    default="micro",
     help="The model variant (configuration) to benchmark. E.g. 7b, 13b, 70b.",
 )
 parser.add_argument(


### PR DESCRIPTION
three minor changes in the included training code:

* Fix a bug that introduced by a prior change such that sd was not initialized
* Default to the micro model so script works for testing with default arguments on a laptop
* Initialize the model with `reset_parameters()` if present on the model. This is the convention used in pytorch nn.Modules, and I think we expect to use this after https://github.com/foundation-model-stack/foundation-model-stack/pull/177. After 177 lands, we won't still be running an init function from the constructor, so this change will handle that.

