### PR TITLE
Update ghstack-perm-check.py to fix non-None check

### DIFF
--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -131,7 +131,7 @@ class GHStackChecks:
         self.must(actor, "Event actor not found!")
 
         pr_owner = self.PR["user"]["login"]
-        self.must(actor, "PR Owner not found!")
+        self.must(pr_owner, "PR Owner not found!")
 
         # If the comment was not left by the owner, it's only allowed for owners
         if actor != pr_owner:


### PR DESCRIPTION
The check for non-None pr_owner incorrectly re-tested actor which was previously confirmed to not be None.

