### PR TITLE
Allow Llama to return embedding vectors, not just logits

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -151,7 +151,7 @@ def _activation_checkpoint_check_fn(layer):
     return False
 
 
-from torch.disctributed.fsdp.wrap import transformer_auto_wrap_policy
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 import functools
 from llama import LLaMABlock
 def _fsdp_wrap(

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -151,9 +151,6 @@ def _activation_checkpoint_check_fn(layer):
     return False
 
 
-from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
-import functools
-from fms.models.llama import LLaMABlock
 def _fsdp_wrap(
     model: nn.Module,
     distributed_strategy: Optional[str],
@@ -190,8 +187,7 @@ def _fsdp_wrap(
         device_id=device.index,
         limit_all_gathers=True,
         use_orig_params=True,
-        # auto_wrap_policy=_fsdp_autowrap_policy,
-        auto_wrap_policy=functools.partial(transformer_auto_wrap_policy, transformer_layer_cls={LLaMABlock}),
+        auto_wrap_policy=_fsdp_autowrap_policy,
         mixed_precision=mp_policy,
         sharding_strategy=dp_strategy,
     )

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -153,7 +153,7 @@ def _activation_checkpoint_check_fn(layer):
 
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 import functools
-from llama import LLaMABlock
+from fms.models.llama import LLaMABlock
 def _fsdp_wrap(
     model: nn.Module,
     distributed_strategy: Optional[str],

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -151,6 +151,9 @@ def _activation_checkpoint_check_fn(layer):
     return False
 
 
+from torch.disctributed.fsdp.wrap import transformer_auto_wrap_policy
+import functools
+from llama import LLaMABlock
 def _fsdp_wrap(
     model: nn.Module,
     distributed_strategy: Optional[str],
@@ -187,7 +190,8 @@ def _fsdp_wrap(
         device_id=device.index,
         limit_all_gathers=True,
         use_orig_params=True,
-        auto_wrap_policy=_fsdp_autowrap_policy,
+        # auto_wrap_policy=_fsdp_autowrap_policy,
+        auto_wrap_policy=functools.partial(transformer_auto_wrap_policy, transformer_layer_cls={LLaMABlock}),
         mixed_precision=mp_policy,
         sharding_strategy=dp_strategy,
     )

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -303,6 +303,7 @@ class GPTBigCode(nn.Module):
         past_key_value_states: Optional[Tuple[torch.FloatTensor,]] = None,
         use_cache: bool = False,
         attn_algorithm: Optional[str] = None,
+        include_embeds: bool = False,
     ):
         output, cache = self.base_model(
             x,
@@ -315,10 +316,14 @@ class GPTBigCode(nn.Module):
 
         preds = self.head(output)
 
+        out = [preds]
         if use_cache:
-            return preds, cache
-        else:
-            return preds
+            out.append(cache)
+        if include_embeds:
+            out.append(output)
+        if len(out) == 1:
+            return out[0]
+        return out
 
 
 _santacoder_config = GPTBigCodeConfig(

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -317,6 +317,7 @@ class LLaMA(nn.Module):
         use_cache=False,
         only_last_token=False,
         attn_algorithm=None,
+        include_embeds=False,
     ):
         output, cache = self._helper(
             x, mask, position_ids, past_key_value_states, use_cache, attn_algorithm
@@ -326,10 +327,14 @@ class LLaMA(nn.Module):
             output = output[:, -1, :]
         preds = self.shared(output, reverse=True)
 
+        out = [preds]
         if use_cache:
-            return preds, cache
-        else:
-            return preds
+            out.append(cache)
+        if include_embeds:
+            out.append(output)
+        if len(out) == 1:
+            return out[0]
+        return out
 
 
 # Register common LLaMA variants with the model registration API

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -52,6 +52,8 @@ def generate(
         num_beams: TODO: support beam search
         use_cache: requires that the model accept use_cache and
             past_key_value_states args in forward method.
+        include_embeds: track and return embedding vectors for 
+            each generated token. Used for speculator training.
     """
     batched = False
     if num_beams != 1:


### PR DESCRIPTION
Training the speculators in `fms-extras` requires access to the final embedding vectors of the base model, not just the token predictions. I have added an `include_embeds` flag to `Llama.forward()`, which adds the latent tensor to the return list when enabled. Default is disabled and behavior in that setting is unchanged. This change mirrors the one in the older #121