### PR TITLE
added a to_tp check when applying tp so custom modules could enable tp

### DIFF
--- a/fms/utils/tp_wrapping.py
+++ b/fms/utils/tp_wrapping.py
@@ -15,7 +15,9 @@ from fms.modules.positions import Alibi
 # this probably belongs somewhere else but can't go in fms.distribtued b/c
 # circular dependency.
 def _tp_wrapped(module: nn.Module, group: ProcessGroup):
-    if isinstance(module, FeedForwardBlock):
+    if hasattr(module, "to_tp"):
+        return module.to_tp(group)
+    elif isinstance(module, FeedForwardBlock):
         return TPFeedForwardBlock.import_module(module, group)
     elif isinstance(module, GatedLinearUnit):
         return TPGatedLinearUnit.import_module(module, group)


### PR DESCRIPTION
Currently, if a user creates a custom module, there is no way to apply tensor-parallel to it given we only look for specific fms classes. This simple change enables a user to implement a `to_tp(group)` method which returns the TPModule version of the module. In the future, we may want to reconsider how TP is being done using something like DTensor, however in the short term, this will enable tp on custom modules.