### PR TITLE
Update TP code to PT 2.2-nightlies compatibility

### DIFF
--- a/fms/distributed/tensorparallel.py
+++ b/fms/distributed/tensorparallel.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch._inductor.ir as ir
+import torch._inductor.lowering as lowering
 import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 from torch import nn
@@ -44,6 +45,10 @@ def apply_embedding_tp(par_mod: nn.Embedding, mod: nn.Embedding, world_size, ran
     # print(f"For rank {rank}, we have the following weights: Base weight {mod.weight} bias {mod.bias}; Par weight {par_mod.weight}, bias {par_mod.bias}")
 
 
+## Fixes for PT 2.2 collectives until PT 2.3 is released
+
+
+# Fix 1: https://github.com/pytorch/pytorch/issues/121311
 def get_volatile_reads_fixed(self):
     inp = self.inputs[0]
     if isinstance(inp, ir._CollectiveKernel):
@@ -64,6 +69,42 @@ def get_volatile_reads_fixed(self):
 
 ir._WaitKernel.get_volatile_reads = get_volatile_reads_fixed
 
+# Fix 2: These are fixed already in nightlies and will be in 2.3
+for overload in torch.ops._c10d_functional.all_reduce.overloads():
+    other_fn = getattr(torch.ops._c10d_functional.all_reduce, overload)
+    if other_fn in lowering.lowerings:
+        del lowering.lowerings[other_fn]
+
+
+@lowering.register_lowering(torch.ops._c10d_functional.all_reduce)
+def _all_reduce_fixed(inp, reduce_op, group_name):
+    inp = torch.clone(inp)
+    ir._CollectiveKernel.create_inplace(
+        torch.ops._c10d_functional.all_reduce_.default,
+        ir.ExternKernel.require_contiguous(inp),
+        reduce_op,
+        group_name,
+    )
+    return inp
+
+
+for overload in torch.ops._c10d_functional.all_gather_into_tensor.overloads():
+    other_fn = getattr(torch.ops._c10d_functional.all_gather_into_tensor, overload)
+    if other_fn in lowering.lowerings:
+        del lowering.lowerings[other_fn]
+
+
+@lowering.register_lowering(torch.ops._c10d_functional.all_gather_into_tensor)
+def _all_gather_into_tensor(inp, group_size, group_name):
+    return ir.TensorBox.create(
+        ir._CollectiveKernel.create_out_of_place(
+            torch.ops._c10d_functional.all_gather_into_tensor.default,
+            ir.ExternKernel.require_contiguous(inp),
+            group_size,
+            group_name,
+        )
+    )
+
 
 def _all_gather(input_: torch.Tensor) -> torch.Tensor:
     """Gather the input tensor across model parallel group."""
@@ -75,9 +116,12 @@ def _all_gather(input_: torch.Tensor) -> torch.Tensor:
     # The transposes here are to avoid excessive recompilation due to split()
     # specializing the dimension where the all_gather is happening
     last_dim = input_.dim() - 1
+    # Starting PT 2.3, we can go back to funcol.all_gather_tensor
     return (
-        funcol.all_gather_tensor(
-            input_.transpose(0, last_dim).contiguous(), 0, list(range(world_size))
+        torch.ops._c10d_functional.wait_tensor(
+            torch.ops._c10d_functional.all_gather_into_tensor(
+                input_.transpose(0, last_dim).contiguous(), world_size, "default"
+            )
         )
         .transpose(0, last_dim)
         .contiguous()
@@ -91,7 +135,10 @@ def _all_reduce(input_: torch.Tensor) -> torch.Tensor:
     if world_size == 1:
         return input_
 
-    return funcol.all_reduce(input_, "sum", list(range(world_size)))
+    # Starting PT 2.3, we can go back to funcol.all_reduce
+    return torch.ops._c10d_functional.wait_tensor(
+        torch.ops._c10d_functional.all_reduce(input_, "sum", "default")
+    )
 
 
 def _split(input_: torch.Tensor, rank, world_size) -> torch.Tensor:

--- a/fms/distributed/tensorparallel.py
+++ b/fms/distributed/tensorparallel.py
@@ -1,12 +1,9 @@
 # mypy: disable-error-code="method-assign,misc"
-from typing import Any, List, Tuple
 
 import torch
-import torch._dynamo as dynamo
-import torch._inductor.codegen.wrapper as inductor_wrapper
-import torch._inductor.ir as inductor_ir
-import torch._inductor.lowering as inductor_lowering
-import torch.distributed._functional_collectives as distfunc
+import torch._inductor.ir as ir
+import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
 from torch import nn
 
 
@@ -47,117 +44,30 @@ def apply_embedding_tp(par_mod: nn.Embedding, mod: nn.Embedding, world_size, ran
     # print(f"For rank {rank}, we have the following weights: Base weight {mod.weight} bias {mod.bias}; Par weight {par_mod.weight}, bias {par_mod.bias}")
 
 
-def _all_reduce(input_: torch.Tensor) -> torch.Tensor:
-    """All-reduce the input tensor across model parallel group."""
-    world_size = torch.distributed.get_world_size()
-
-    if world_size == 1:
-        return input_
-
-    return distfunc.all_reduce(input_, "sum", list(range(world_size)))
-
-
-# Fix #1 is porting the code changes in https://github.com/pytorch/pytorch/pull/108811
-@classmethod
-def wait_create(cls, collective_op: "inductor_ir.TensorBox"):
-    collective_op.decide_layout()
-    return inductor_ir.Wait(
-        layout=inductor_ir.AliasedLayout(collective_op),  # type: ignore[arg-type]
-        inputs=[collective_op],
-    )
+def get_volatile_reads_fixed(self):
+    inp = self.inputs[0]
+    if isinstance(inp, ir._CollectiveKernel):
+        # Out-of-place single-output
+        return [inp.inputs[0]]
+    elif isinstance(inp, ir.MultiOutput):
+        # Out-of-place multi-output
+        coll = inp.inputs[0]
+        if isinstance(coll, ir._CollectiveKernel):
+            _, idx = inp.indices[0]
+            return [coll.inputs[idx]]
+        return []  # e.g. regular FallbackKernel
+    else:
+        # In-place requires no additional deps handling for volatile
+        # reads since the inputs are mutated.
+        return []
 
 
-inductor_ir.Wait.create = wait_create  # type: ignore[assignment]
-
-inductor_ir.AllReduce.get_mutation_names = lambda self: [self.inputs[0].get_name()]  # type: ignore[attr-defined]
-
-
-@classmethod
-def all_reduce_create(
-    cls,
-    x: "inductor_ir.TensorBox",
-    reduce_op: str,
-    tag: str,
-    ranks: List[int],
-    group_size: int,
-):
-    inplace_inputs = cls.wrap_inputs_as_inplace([x])
-    layout = inductor_ir.MutationLayout(inplace_inputs[0])
-
-    _ = inductor_ir.AllReduce(
-        layout=layout,
-        inputs=inplace_inputs,
-        constant_args=[tag, ranks, group_size],
-        reduce_op=reduce_op,
-    )
-    return inplace_inputs[0]
-
-
-inductor_ir.AllReduce.create = all_reduce_create  # type: ignore[assignment]
-
-
-def wcg_codegen_free(self, buffer):
-    name = buffer.get_name()
-
-    # can be freed but not reused
-    # TODO: Port this one-line fix to PyTorch
-    if isinstance(buffer, (inductor_ir.InputBuffer, inductor_ir.OutputBuffer)):
-        self.writeline(self.make_buffer_free(buffer))
-        return
-
-    if not self.can_reuse(buffer):
-        return
-    self.freed.add(name)
-
-    layout = buffer.get_layout()
-    if isinstance(layout, (inductor_ir.AliasedLayout, inductor_ir.MultiOutputLayout)):
-        self.writeline(self.make_buffer_free(buffer))
-        return
-
-    self.writeline(inductor_wrapper.FreeIfNotReusedLine(self, buffer))
-
-
-inductor_wrapper.WrapperCodeGen.codegen_free = wcg_codegen_free
-# End of fix #1
-
-
-# Fix #2: Asserts + dynamic shapes create graph breaks
-# This function is redefined from torch.distributed._functional_collectives.all_gather_tensor
-# to remove an assert that creates an extra graph break
-def _all_gather_tensor(
-    self: torch.Tensor,
-    gather_dim: int,
-    group: distfunc.RANK_TYPES,
-    tag: str = "",
-):
-    tag, rankset, group_size = distfunc._expand_group(group, tag)
-    tensor = torch.ops.c10d_functional.all_gather_into_tensor(self, tag, rankset, group_size)  # type: ignore[attr-defined]
-    res = distfunc._maybe_wrap_tensor(tensor)
-    # TODO this should be done inside AsyncCollectiveTensor to delay the wait() call
-    if gather_dim != 0:
-        res = torch.cat(torch.chunk(res, group_size, dim=0), dim=gather_dim)
-    return res
-
-
-# Fix #3: Avoid recompiles on batch size for embedding + TP (until https://github.com/pytorch/pytorch/pull/109561 lands)
-for overload in torch.ops.c10d_functional.all_gather_into_tensor.overloads():
-    other_fn = getattr(torch.ops.c10d_functional.all_gather_into_tensor, overload)
-    if other_fn in inductor_lowering.lowerings:
-        del inductor_lowering.lowerings[other_fn]
-
-
-@inductor_lowering.register_lowering(torch.ops.c10d_functional.all_gather_into_tensor)
-def all_gather_into_tensor(shard, tag, ranks, group_size):
-    return inductor_ir.TensorBox.create(
-        inductor_ir.AllGatherIntoTensor.create(
-            inductor_ir.ExternKernel.require_contiguous(shard), tag, ranks, group_size
-        )
-    )
+ir._WaitKernel.get_volatile_reads = get_volatile_reads_fixed
 
 
 def _all_gather(input_: torch.Tensor) -> torch.Tensor:
     """Gather the input tensor across model parallel group."""
-    world_size = torch.distributed.get_world_size()
+    world_size = dist.get_world_size()
 
     if world_size == 1:
         return input_
@@ -166,14 +76,22 @@ def _all_gather(input_: torch.Tensor) -> torch.Tensor:
     # specializing the dimension where the all_gather is happening
     last_dim = input_.dim() - 1
     return (
-        _all_gather_tensor(
-            input_.transpose(0, last_dim).contiguous(),
-            0,
-            list(range(world_size)),
+        funcol.all_gather_tensor(
+            input_.transpose(0, last_dim).contiguous(), 0, list(range(world_size))
         )
         .transpose(0, last_dim)
         .contiguous()
     )
+
+
+def _all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across model parallel group."""
+    world_size = dist.get_world_size()
+
+    if world_size == 1:
+        return input_
+
+    return funcol.all_reduce(input_, "sum", list(range(world_size)))
 
 
 def _split(input_: torch.Tensor, rank, world_size) -> torch.Tensor:

--- a/scripts/eval_harness.py
+++ b/scripts/eval_harness.py
@@ -95,10 +95,10 @@ local_rank = int(os.getenv("LOCAL_RANK", 0))
 world_size = int(os.getenv("WORLD_SIZE", 1))
 if args.device_type == "cuda":
     device = torch.device(args.device_type, local_rank)
+    torch.cuda.set_device(device)
 else:
     device = torch.device(args.device_type)
 
-torch.set_default_device(device)
 torch.set_default_dtype(torch.half)
 
 # requires setting environment variable: `CUBLAS_WORKSPACE_CONFIG=:4096:8`
@@ -107,6 +107,8 @@ if args.deterministic:
 
 if args.distributed:
     dist.init_process_group()
+    # Fix until PT 2.3
+    torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
 
 print("loading model")
 if args.distributed:

--- a/scripts/hf_compile_example.py
+++ b/scripts/hf_compile_example.py
@@ -1,13 +1,16 @@
 import argparse
-import transformers
-from fms.models import llama
 import os
 import time
+
 import torch
+import transformers
 from torch import nn
-from fms.models.hf.llama import modeling_llama_hf
 from transformers import pipeline
+
+from fms.models import llama
+from fms.models.hf.llama import modeling_llama_hf
 from fms.models.hf.utils import register_fms_models
+
 
 # This script demonstrates how to use FMS model implementations with HF formatted
 # weights.

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -85,10 +85,10 @@ local_rank = int(os.getenv("LOCAL_RANK", 0))
 world_size = int(os.getenv("WORLD_SIZE", 1))
 if args.device_type == "cuda":
     device = torch.device(args.device_type, local_rank)
+    torch.cuda.set_device(device)
 else:
     device = torch.device(args.device_type)
 
-torch.set_default_device(device)
 torch.set_default_dtype(torch.half)
 
 # requires setting environment variable: `CUBLAS_WORKSPACE_CONFIG=:4096:8`
@@ -97,6 +97,8 @@ if args.deterministic:
 
 if args.distributed:
     dist.init_process_group()
+    # Fix until PT 2.3
+    torch._C._distributed_c10d._register_process_group("default", dist.group.WORLD)
 
 print("loading model")
 if args.distributed:


### PR DESCRIPTION
This PR updates our collectives and the code surrounding it so we can take advantage of the new native functional collectives introduced in PT 2.2. These allow for things like torch.compiling them in CPU and are compatible with torch.export, for example. There's some new fixes that should be in 2.3

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #206
* #205
* #204
* #203
* #210
* #209
* #201
* __->__ #200

