### PR TITLE
Support pre-allocated kv-cache case for Rope

### DIFF
--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -101,7 +101,7 @@ class Alibi(PositionEncoder):
 
 class RotaryEmbedding(PositionEncoder):
     def __init__(
-        self, dim: int, ratio: int = 10_000, max_seq_len=2048, ntk_scaling=False
+        self, dim: int, ratio: float = 10_000.0, max_seq_len=2048, ntk_scaling=False
     ):
         """
         This implementation of Rotary Position Embeddings (RoPE) avoids
@@ -240,7 +240,7 @@ class RotaryEmbedding(PositionEncoder):
             position_ids = torch.arange(
                 0, seq_len, dtype=torch.long, device=q.device
             ).repeat(k.size(0), 1)
-            if use_cache and past_kv_state is not None:
+            if use_cache and past_kv_state is not None and past_kv_state[0].numel() > 0:
                 position_ids += past_kv_state[0].size(2)
 
         q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

