### PR TITLE
Fix mask's dtype in gpt_bigcode

### DIFF
--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -193,7 +193,7 @@ class GPTBigCodeHeadless(nn.Module):
             # we are caching and can assume all 1s in the mask
             if use_cache and klen != 1 and qlen == 1:
                 # b x h x qlen x kvlen
-                mask = torch.ones(qlen, klen, device=x.device)
+                mask = torch.ones(qlen, klen, device=x.device).bool()
             else:
                 pad_id: int = self.config.pad_id
                 is_pad: torch.Tensor = x == pad_id

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -193,7 +193,7 @@ class GPTBigCodeHeadless(nn.Module):
             # we are caching and can assume all 1s in the mask
             if use_cache and klen != 1 and qlen == 1:
                 # b x h x qlen x kvlen
-                mask = torch.ones(qlen, klen, device=x.device).bool()
+                mask = torch.ones(qlen, klen, dtype=torch.bool, device=x.device)
             else:
                 pad_id: int = self.config.pad_id
                 is_pad: torch.Tensor = x == pad_id


### PR DESCRIPTION
Fixes error `RuntimeError: Expected attn_mask dtype to be bool or to match query dtype, but got attn_mask.dtype: float and  query.dtype: c10::BFloat16 instead.` in the following stack trace, for a bfloat16 gpt_bigcode model variant:

```  
  File "/lustre/suneja/foundation-model-stack/fms/utils/generation.py", line 75, in generate    
    output = model(input_ids, **kwargs)
  File "/lustre/suneja/foundation-model-stack/fms/models/gpt_bigcode.py", line 313, in forward
    output, cache = self.base_model(    
  File "/lustre/suneja/foundation-model-stack/fms/models/gpt_bigcode.py", line 236, in forward
    output = layer(
  File "/lustre/suneja/foundation-model-stack/fms/models/gpt_bigcode.py", line 81, in forward
    x = self.attn(            
  File "/lustre/suneja/foundation-model-stack/fms/modules/attention.py", line 203, in forward
    attn = F.scaled_dot_product_attention(
  
  