### PR TITLE
Bump pytorch version in setup.py (other places are already correct)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Used to install pinned dependencies
 # Useful for dev/test jobs caches
 # Must be kept in sync with setup.py
-torch == 2.2.0 # This is what is installed in CI today
+torch ~= 2.2.0 # This is what is installed in CI today

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="IBM Foundation Model Stack",
     url="https://github.com/foundation-model-stack/foundation-model-stack",
     packages=find_packages(),
-    install_requires=["torch >= 2.1"],
+    install_requires=["torch >= 2.2"],
     extras_require={"hf": ["transformers >= 4.35.0"]},
     license="Apache License 2.0",
     classifiers=[


### PR DESCRIPTION
@dakshiagrawal found that current scripts break as they expect PT 2.2, but by default the setup will still install 2.1

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #222

