### PR TITLE
Avoid runtime exception on non-CUDA environment

### DIFF
--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -225,7 +225,8 @@ def one_token(model, use_cache):
     if local_rank == 0 and not args.skip_correctness_check:
         torch.testing.assert_close(actual, expected)
     else:
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
 
 
 def end_to_end(model, use_cache, expected=None):
@@ -247,7 +248,8 @@ def end_to_end(model, use_cache, expected=None):
     if expected is not None and not args.skip_correctness_check:
         torch.testing.assert_close(result, expected)
     else:
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
     return result
 
 

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -225,7 +225,7 @@ def one_token(model, use_cache):
     if local_rank == 0 and not args.skip_correctness_check:
         torch.testing.assert_close(actual, expected)
     else:
-        if torch.cuda.is_available():
+        if args.device_type == "cuda":
             torch.cuda.synchronize()
 
 
@@ -248,7 +248,7 @@ def end_to_end(model, use_cache, expected=None):
     if expected is not None and not args.skip_correctness_check:
         torch.testing.assert_close(result, expected)
     else:
-        if torch.cuda.is_available():
+        if args.device_type == "cuda":
             torch.cuda.synchronize()
     return result
 


### PR DESCRIPTION
This PR adds a guard to check whether cuda is available before calling cuda function. The runtime error occurs w/o this PR on non-CUDA environment (e.g. PyTorch cpu package).