### PR TITLE
Make results deterministic in inference.py

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -1,7 +1,9 @@
 import argparse
 import itertools
 import os
+import random
 
+import numpy as np
 import torch
 import torch._inductor.config
 from torch import distributed as dist
@@ -93,6 +95,10 @@ torch.set_default_dtype(torch.half)
 
 # requires setting environment variable: `CUBLAS_WORKSPACE_CONFIG=:4096:8`
 if args.deterministic:
+    SEED = 42
+    random.seed(SEED)
+    torch.manual_seed(SEED)  # pytorch random seed
+    np.random.seed(SEED)  # numpy random seed
     torch.use_deterministic_algorithms(True)
 
 if args.distributed:


### PR DESCRIPTION
This is a follow-up PR of https://github.com/foundation-model-stack/foundation-model-stack/pull/221.

This PR makes consistent with `--deterministic` behavior by setting a specific random seed. This PR will make our debugging easier by generating the same result.