### PR TITLE
fixed TP support for MQA and world size > kvheads

### DIFF
--- a/fms/modules/embedding.py
+++ b/fms/modules/embedding.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed
@@ -215,10 +215,10 @@ class TPWordEmbedding(WordEmbedding, TPModule):
         )
         return tp_we
 
-    def colwise_param_names(self) -> List[str]:
+    def colwise_params(self) -> Dict[str, int]:
         if self.reversible and not self.tie_weights:
-            return ["head"]
-        return []
+            return {"head": 1}
+        return {}
 
     def embedding_param_names(self) -> List[str]:
         emb_weights = ["emb"]

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import torch
 import torch.distributed
@@ -118,8 +118,8 @@ class TPFeedForwardBlock(FeedForwardBlock, TPModule):
         )
         self.setup_tp(rank, world_size)
 
-    def colwise_param_names(self) -> List[str]:
-        return ["w1"]
+    def colwise_params(self) -> Dict[str, int]:
+        return {"w1": 1}
 
     def rowwise_param_names(self) -> List[str]:
         return ["w2"]
@@ -256,8 +256,8 @@ class TPGatedLinearUnit(GatedLinearUnit, TPModule):
         )
         self.setup_tp(rank, world_size)
 
-    def colwise_param_names(self) -> List[str]:
-        return ["w1", "wg"]
+    def colwise_params(self) -> Dict[str, int]:
+        return {"w1": 1, "wg": 1}
 
     def rowwise_param_names(self) -> List[str]:
         return ["w2"]

--- a/fms/modules/tp.py
+++ b/fms/modules/tp.py
@@ -1,6 +1,6 @@
 import itertools
 from abc import ABCMeta, abstractmethod
-from typing import List, Type
+from typing import Dict, List, Type
 
 import torch
 import torch.nn as nn
@@ -31,8 +31,8 @@ class TPModule(nn.Module, metaclass=ABCMeta):
         self.rank = rank
         self.world_size = world_size
 
-    def colwise_param_names(self) -> List[str]:
-        return []
+    def colwise_params(self) -> Dict[str, int]:
+        return {}
 
     def rowwise_param_names(self) -> List[str]:
         return []

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -502,7 +502,7 @@ def _load_partial_state_dict(
                     )
                 else:
                     # it's possible for a TPModule to decide not to shard a parameter, in which case we just need to
-                    # copy it. For example, this occurs in MQA of MultiHeadAttention
+                    # copy it.
                     _copy_if_present(param, tensor_value)
         except AttributeError:
             unused_params.append(key)


### PR DESCRIPTION
Currently in FMS, we are not supporting large world sizes for MHA. This PR addresses that, which simultaneously solves issues with mqa in MHA when running in tensor-parallel. A pathway was also added to support weights not being specified as being TP sharded in a TPModule

One design choice made here was to change the `colwise_param_names` to `colwise_params` opting to return a dict rather than a list. This dict will include the list values as keys, but for each value include an expansion factor which is used to determine duplication when copying to certain ranks. For instance, if world_size is 12 and kv_heads is 4, the expansion factor would be set to 3, in which case when doing a columnwise copy:

rank 0,1,2 would be duplicates
rank 3,4,5 would be duplicates
rank 6,7,8 would be duplicates
rank 9,10,11 would be duplicates

Test with LLaMA 70B 64-way tp