### PR TITLE
Remove FusableWeightsMissingError

### DIFF
--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -12,7 +12,6 @@ from fms.modules.feedforward import FeedForwardBlock
 from fms.utils import serialization
 from fms.utils.activation import str_to_activation
 from fms.utils.config import ModelConfig
-from fms.utils.serialization import FusableWeightsMissingError
 
 
 @dataclass
@@ -430,11 +429,6 @@ def _hf_sd_to_fms_sd(hf_sd: Mapping) -> Mapping:
 
         # qkv fused
         if bool(qkv_weight_pattern.match(name)):
-            bias_name = name.replace("weight", "bias")
-            if bias_name not in hf_sd:
-                raise FusableWeightsMissingError([bias_name])
-            new_sd.pop(new_name)
-
             emb_dim = param.size(1)
             num_heads = emb_dim // 128
             num_key_value_heads = (param.size(0) // 128 - num_heads) // 2
@@ -452,8 +446,6 @@ def _hf_sd_to_fms_sd(hf_sd: Mapping) -> Mapping:
             new_sd[f"{prefix}value.weight"] = v
         elif bool(qkv_bias_pattern.match(name)):
             weight_name = name.replace("bias", "weight")
-            if weight_name not in hf_sd:
-                raise FusableWeightsMissingError([weight_name])
             new_sd.pop(new_name)
 
             emb_dim = hf_sd[weight_name].size(1)

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -3,7 +3,7 @@ import os
 from collections import ChainMap
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Callable, List, Mapping, MutableMapping, Optional, Union
+from typing import Any, Callable, List, Mapping, MutableMapping, Optional, Set, Union
 
 import torch
 
@@ -11,6 +11,9 @@ from fms.modules.tp import TPModule
 
 
 __adapters: MutableMapping[str, MutableMapping[str, Callable[[Mapping], Mapping]]] = {}
+__find_neighbors_funcs: MutableMapping[
+    str, MutableMapping[str, Callable[[str, Set[str]], List[str]]]
+] = {}
 
 
 def register_adapter(
@@ -239,6 +242,69 @@ def _load_safetensors_state_dict(
     return sd
 
 
+def register_find_neighbors_func(
+    architecture: str,
+    source: str,
+    find_neighbors_func: Callable[[str, Set[str]], List[str]],
+):
+    """
+    Registers a function to find neighbors of a key in a state dict
+
+    Args:
+    architecture: The name of the model architecture, e.g. 'llama'
+    source: A label representing the format of the weights to be converted.
+            E.g. 'hf'
+    find_neighbors_func: the finding function. It takes a key and a set of
+            keys in a state dict, and returns a list of neighboring keys.
+    """
+    sources: MutableMapping[str, Callable[[str, Set[str]], List[str]]] = {}
+    if architecture in __find_neighbors_funcs:
+        sources = __find_neighbors_funcs[architecture]
+
+    if source in sources:
+        raise KeyError(
+            f"Variant {source} already registered for architecture {architecture}"
+        )
+
+    sources[source] = find_neighbors_func
+    __find_neighbors_funcs[architecture] = sources
+
+
+def _get_find_neighbors_func(architecture, source):
+    if (
+        architecture in __find_neighbors_funcs
+        and source in __find_neighbors_funcs[architecture]
+    ):
+        return __find_neighbors_funcs[architecture][source]
+    return None
+
+
+def _find_key_neighbors(key: str, sd_keys: Set[str], architecture: str, source: str):
+    # If arch + source have a custom architecture,
+    # users can define their own way of finding neighbors,
+    # otherwise assume standard model and find neighbors
+    if _get_find_neighbors_func(architecture, source) != None:
+        return _get_find_neighbors_func(architecture, source)(key, sd_keys)
+
+    # For loading most models that concern us, a good partition is the
+    # one used for FSDP units: everything that is in a layer can
+    # go together and memory usage will be keep in control
+    key_steps = key.split(".")
+    prefix = ""
+    # Navigate the model tree to find a layer index. If not found,
+    # grab that weight alone
+    for idx, step in enumerate(key_steps):
+        prefix = ".".join(key_steps[: idx + 1])
+        if step.isnumeric():
+            prefix += "."
+            break
+    prefix_neighbors = set()
+    for key_in_sd in sd_keys:
+        if prefix in key_in_sd:
+            prefix_neighbors.add(key_in_sd)
+    return list(prefix_neighbors)
+
+
 def load_state_dict_into_model(
     model: torch.nn.Module,
     state_dict: MutableMapping[str, Any],
@@ -278,12 +344,41 @@ def load_state_dict_into_model(
     # 2. Decide if model needs sharding and how (for now only TP)
     needs_tp_sharding = checkpoint_sharding != "tp" and distributed_strategy == "tp"
 
-    # 3. Adapt the model weights and load the weights into the model
+    # 3. Iterate over the weights and load them into the model
+    used_keys = set()
+    sd_keys = set(state_dict.keys())
+
     with torch.no_grad():
-        adapted_state_dict = adapter(state_dict)
-        _load_partial_state_dict(
-            model, adapted_state_dict, needs_tp_sharding, rank, world_size
-        )
+        for key in sd_keys:
+            if key in used_keys:
+                continue
+            used_keys.add(key)
+
+            partial_sd = {key: state_dict[key]}
+            # Find neighbors to the key. If the adapter requires a neighbor and
+            # this function doesn't find it, it will crash. Users can define their
+            # own finding function if ours is not enough for a really custom arch
+            remaining_keys = sd_keys.difference(used_keys)
+            neighbors = _find_key_neighbors(key, remaining_keys, architecture, source)
+            for neighbor in neighbors:
+                partial_sd[neighbor] = state_dict[neighbor]
+                used_keys.add(neighbor)
+            for psd_key in partial_sd.keys():
+                if partial_sd[psd_key].device != initial_device:
+                    partial_sd[psd_key] = partial_sd[psd_key].to(device=initial_device)
+            fms_partial_sd = adapter(partial_sd)
+            _load_partial_state_dict(
+                model, fms_partial_sd, needs_tp_sharding, rank, world_size
+            )
+            # Be aggressive in removing weights to save as much memory as possible
+            for p_key in partial_sd.keys():
+                if isinstance(state_dict, ChainMap):
+                    for child_sd in state_dict.maps:
+                        child_sd.pop(p_key, None)
+                else:
+                    state_dict.pop(p_key)
+            del partial_sd
+            del fms_partial_sd
 
 
 def _copy_colwise(param: torch.nn.Parameter, tensor_value, is_bias, rank, world_size):

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -11,9 +11,6 @@ from fms.modules.tp import TPModule
 
 
 __adapters: MutableMapping[str, MutableMapping[str, Callable[[Mapping], Mapping]]] = {}
-__find_neighbors_funcs: MutableMapping[
-    str, MutableMapping[str, Callable[[str, Set[str]], List[str]]]
-] = {}
 
 
 def register_adapter(
@@ -242,50 +239,7 @@ def _load_safetensors_state_dict(
     return sd
 
 
-def register_find_neighbors_func(
-    architecture: str,
-    source: str,
-    find_neighbors_func: Callable[[str, Set[str]], List[str]],
-):
-    """
-    Registers a function to find neighbors of a key in a state dict
-
-    Args:
-    architecture: The name of the model architecture, e.g. 'llama'
-    source: A label representing the format of the weights to be converted.
-            E.g. 'hf'
-    find_neighbors_func: the finding function. It takes a key and a set of
-            keys in a state dict, and returns a list of neighboring keys.
-    """
-    sources: MutableMapping[str, Callable[[str, Set[str]], List[str]]] = {}
-    if architecture in __find_neighbors_funcs:
-        sources = __find_neighbors_funcs[architecture]
-
-    if source in sources:
-        raise KeyError(
-            f"Variant {source} already registered for architecture {architecture}"
-        )
-
-    sources[source] = find_neighbors_func
-    __find_neighbors_funcs[architecture] = sources
-
-
-def _get_find_neighbors_func(architecture, source):
-    if (
-        architecture in __find_neighbors_funcs
-        and source in __find_neighbors_funcs[architecture]
-    ):
-        return __find_neighbors_funcs[architecture][source]
-    return None
-
-
-def _find_key_neighbors(key: str, sd_keys: Set[str], architecture: str, source: str):
-    # If arch + source have a custom architecture,
-    # users can define their own way of finding neighbors,
-    # otherwise assume standard model and find neighbors
-    if _get_find_neighbors_func(architecture, source) != None:
-        return _get_find_neighbors_func(architecture, source)(key, sd_keys)
-
+def _find_key_neighbors(key: str, sd_keys: Set[str]):
     # For loading most models that concern us, a good partition is the
     # one used for FSDP units: everything that is in a layer can
     # go together and memory usage will be keep in control
@@ -356,10 +310,9 @@ def load_state_dict_into_model(
 
             partial_sd = {key: state_dict[key]}
             # Find neighbors to the key. If the adapter requires a neighbor and
-            # this function doesn't find it, it will crash. Users can define their
-            # own finding function if ours is not enough for a really custom arch
+            # this function doesn't find it, it will crash.
             remaining_keys = sd_keys.difference(used_keys)
-            neighbors = _find_key_neighbors(key, remaining_keys, architecture, source)
+            neighbors = _find_key_neighbors(key, remaining_keys)
             for neighbor in neighbors:
                 partial_sd[neighbor] = state_dict[neighbor]
                 used_keys.add(neighbor)

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -310,7 +310,10 @@ def load_state_dict_into_model(
 
             partial_sd = {key: state_dict[key]}
             # Find neighbors to the key. If the adapter requires a neighbor and
-            # this function doesn't find it, it will crash.
+            # this function doesn't find it, it will crash. This is useful when
+            # adapters merge multiple weights into one, e.g. if the source state
+            # dict has unfused q,k,v projections and your model has fused qkv, you
+            # want your partial_sd to have the three weights available at a time
             remaining_keys = sd_keys.difference(used_keys)
             neighbors = _find_key_neighbors(key, remaining_keys)
             for neighbor in neighbors:


### PR DESCRIPTION
Now that we are using mmap for loading, we no longer need FusableWeightsMissingError. This also simplifies our model loading as we no longer need to run the adapter on a partial state dict.

- #244
- #243
- #248 
- -> #241