### PR TITLE
Swap kv-cache to be B x S x H x E for better compatibility and efficiency

### DIFF
--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -86,9 +86,6 @@ class MultiHeadAttention(nn.Module):
                 if self.use_bias:
                     m.bias.data.zero_()
 
-    def to_tp(self, group: ProcessGroup) -> "TPMultiHeadAttention":
-        return TPMultiHeadAttention.import_module(self, group)
-
     def forward(
         self,
         q,
@@ -154,15 +151,15 @@ class MultiHeadAttention(nn.Module):
                     queries, keys, position_ids, past_key_value_state, use_cache
                 )
 
-        queries = queries.transpose(2, 1)  # / (self.emb_kq_per_head**(1/4))
-        keys = keys.transpose(2, 1)  # / (self.emb_kq_per_head**(1/4))
-        values = values.transpose(2, 1)  # compatible with QK.T
-
         # if you want to use caching and past_key_value_state is not None meaning you have values in your cache
-        if use_cache and past_key_value_state is not None:
+        if (
+            use_cache
+            and past_key_value_state is not None
+            and past_key_value_state[0].numel() > 0
+        ):
             if is_self:
-                keys = torch.cat((past_key_value_state[0], keys), dim=2)
-                values = torch.cat((past_key_value_state[1], values), dim=2)
+                keys = torch.cat((past_key_value_state[0], keys), dim=1)
+                values = torch.cat((past_key_value_state[1], values), dim=1)
             else:
                 keys = past_key_value_state[0]
                 values = past_key_value_state[1]
@@ -181,17 +178,20 @@ class MultiHeadAttention(nn.Module):
         else:
             attn_mask = mask
 
+        queries_sdpa = queries.transpose(2, 1)  # / (self.emb_kq_per_head**(1/4))
+        keys_sdpa = keys.transpose(2, 1)  # / (self.emb_kq_per_head**(1/4))
+        values_sdpa = values.transpose(2, 1)  # compatible with QK.T
+
         # Expand kv so black-box attn will work
         expansion = self.nheads // self.kvheads
         # k/v: b h l d
         if expansion != 1:
-            keys_e = keys.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
-            values_e = (
-                values.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
+            keys_sdpa = (
+                keys_sdpa.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
             )
-        else:
-            keys_e = keys
-            values_e = values
+            values_sdpa = (
+                values_sdpa.unsqueeze(2).expand(-1, -1, expansion, -1, -1).flatten(1, 2)
+            )
 
         if attn_algorithm:
             # Pick which fused attn kernels will run.
@@ -204,9 +204,9 @@ class MultiHeadAttention(nn.Module):
             torch.backends.cuda.enable_math_sdp(use_math)
 
         attn = F.scaled_dot_product_attention(
-            queries,
-            keys_e,
-            values_e,
+            queries_sdpa,
+            keys_sdpa,
+            values_sdpa,
             attn_mask=attn_mask,
             dropout_p=self.p_dropout if self.training else 0.0,
             is_causal=is_causal_mask,

--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -101,7 +101,7 @@ class Alibi(PositionEncoder):
 
 class RotaryEmbedding(PositionEncoder):
     def __init__(
-        self, dim: int, ratio: int = 10_000, max_seq_len=2048, ntk_scaling=False
+        self, dim: int, ratio: float = 10_000.0, max_seq_len=2048, ntk_scaling=False
     ):
         """
         This implementation of Rotary Position Embeddings (RoPE) avoids
@@ -240,8 +240,8 @@ class RotaryEmbedding(PositionEncoder):
             position_ids = torch.arange(
                 0, seq_len, dtype=torch.long, device=q.device
             ).repeat(k.size(0), 1)
-            if use_cache and past_kv_state is not None:
-                position_ids += past_kv_state[0].size(2)
+            if use_cache and past_kv_state is not None and past_kv_state[0].numel() > 0:
+                position_ids += past_kv_state[0].size(1)
 
         q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
         k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2


### PR DESCRIPTION
When creating the kv-cache, we can do it in two ways: either we store batch x sequence x heads x embedding (BSHE), or we store batch x heads x sequence x embedding (BHSE. Semantically, and that's why SDPA has that as their API, BHSE, is the one that makes the most sense, as batch and heads are both batching dimensions for the attention operation, while the ops are actually done on the seq x emb dimensions.

That being said, the outputs of the query, key, and value linear projections are in BSHE, and all modern SDPA algorithms (e.g. Flash, mem-efficient, Paged, etc.) want the inputs to be contiguous when in BSHE form, even if their APIs take the BHSE. For example, SDPA will immediately transpose back the inputs when calling Flash.

Therefore, it's more efficient and better compatibility for the future to store in the format most efficient implementations we use actually want.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #206
* #204
* #259
* #203
* #256
* __->__ #255

