### PR TITLE
added attn bias, mlp bias, tie heads support to llama

### DIFF
--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -50,6 +50,9 @@ class LLaMAConfig(ModelConfig):
     p_dropout: float = 0.0
     max_expected_seq_len: int = 4096
     ntk_scaling: bool = False
+    attn_bias: bool = False
+    mlp_bias: bool = False
+    tie_heads: bool = False
 
 
 class LLaMABlock(nn.Module):
@@ -89,7 +92,7 @@ class LLaMABlock(nn.Module):
             self.config.nheads,
             kvheads,
             p_dropout=self.config.p_dropout,
-            use_bias=False,
+            use_bias=self.config.attn_bias,
             position_encoder=rotary_emb,
         )
         self.ff_sub_layer = GatedLinearUnit(
@@ -98,7 +101,7 @@ class LLaMABlock(nn.Module):
             multiple_of=self.config.multiple_of,
             activation_fn=str_to_activation(self.config.activation_fn),
             p_dropout=self.config.p_dropout,
-            use_bias=False,
+            use_bias=self.config.mlp_bias,
         )
 
         if self.config.p_dropout != 0:
@@ -185,7 +188,7 @@ class LLaMA(nn.Module):
             padding_idx=self.config.pad_id,
             abs_pos=False,
             reversible=True,
-            tie_weights=False,
+            tie_weights=self.config.tie_heads,
             bias=False,
         )
         self.shared = self.distributed_strategy.distribute_module(shared)


### PR DESCRIPTION
LLaMA in Huggingface now accepted attn bias and mlp_bias. Adding that here as it is a simple configuration change. In this way, we can now support calico as a specific variant of llama