### PR TITLE
fixes to bug in handling single sentencepiece token

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -122,8 +122,9 @@ def generate(
     return result
 
 
-def truncate_after_eos(result: torch.Tensor, eos_token_id: int) -> torch.Tensor:
-    #def truncate_after_eos(result, eos_token_id):
+def truncate_after_eos(
+    result: torch.Tensor, eos_token_id: Union[int, "Any | None"]
+) -> torch.Tensor:
     """
     Helper function to return a truncated sequence of token IDs stopping at
     (and including) the 'end of sentence' token.

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -127,11 +127,13 @@ def truncate_after_eos(result, eos_token_id):
     Helper function to return a truncated sequence of token IDs stopping at
     (and including) the 'end of sentence' token.
     Currently only handles unbatched sequences.
+
+    Args:
+        result: tensor
+        eos_token_id: integer
     """
     if eos_token_id is None:
         return result
-    if isinstance(eos_token_id, list) and len(eos_token_id) == 1:
-        eos_token_id = eos_token_id[0]
     eos_idx = torch.where(result == eos_token_id)
     eos_idx = eos_idx[0]
     if eos_idx.shape[0] >= 1:

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -123,6 +123,7 @@ def generate(
 
 
 def truncate_after_eos(result: torch.Tensor, eos_token_id: int) -> torch.Tensor:
+    #def truncate_after_eos(result, eos_token_id):
     """
     Helper function to return a truncated sequence of token IDs stopping at
     (and including) the 'end of sentence' token.
@@ -131,8 +132,8 @@ def truncate_after_eos(result: torch.Tensor, eos_token_id: int) -> torch.Tensor:
     if eos_token_id is None:
         return result
     eos_idx = torch.where(result == eos_token_id)
-    eos_idx = eos_idx[0]
-    if eos_idx.shape[0] >= 1:
-        eos_idx = eos_idx[0].item()
-        result = result[: eos_idx + 1]
+    eos_index = eos_idx[0]
+    if eos_index.shape[0] >= 1:
+        index = eos_index[0]
+        result = result[: index + 1]
     return result

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -122,15 +122,11 @@ def generate(
     return result
 
 
-def truncate_after_eos(result, eos_token_id):
+def truncate_after_eos(result: torch.tensor, eos_token_id: int) -> torch.tensor:
     """
     Helper function to return a truncated sequence of token IDs stopping at
     (and including) the 'end of sentence' token.
     Currently only handles unbatched sequences.
-
-    Args:
-        result: tensor
-        eos_token_id: integer
     """
     if eos_token_id is None:
         return result

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -130,7 +130,8 @@ def truncate_after_eos(result, eos_token_id):
     """
     if eos_token_id is None:
         return result
-
+    if isinstance(eos_token_id, list) and len(eos_token_id) == 1:
+        eos_token_id = eos_token_id[0]
     eos_idx = torch.where(result == eos_token_id)
     eos_idx = eos_idx[0]
     if eos_idx.shape[0] >= 1:

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -122,7 +122,7 @@ def generate(
     return result
 
 
-def truncate_after_eos(result: torch.tensor, eos_token_id: int) -> torch.tensor:
+def truncate_after_eos(result: torch.Tensor, eos_token_id: int) -> torch.Tensor:
     """
     Helper function to return a truncated sequence of token IDs stopping at
     (and including) the 'end of sentence' token.

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -72,6 +72,10 @@ class CharTokenizer(BaseTokenizer):
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
         if isinstance(tokens, str):
             # returning a single integer to be compatible with other tokenizers
+            if len(tokens) != 1:
+                raise RuntimeError(
+                    f"Only single character str tokens can be converted using the CharTokenizer."
+                )
             token_id = ord(tokens)
             return token_id if token_id < 256 else 0
         return [ord(t) if ord(t) < 256 else 0 for t in tokens]

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -40,7 +40,10 @@ class BaseTokenizer:
         raise NotImplementedError
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
-        """a str parameter will be interpreted as a single token"""
+        """
+        for all tokenizers, a str parameter will be interpreted as a single token,
+        and its output will be a single integer that represents the id.
+        """
         raise NotImplementedError
 
     def convert_tokens_to_string(self, tokens: list[str]):
@@ -67,6 +70,9 @@ class CharTokenizer(BaseTokenizer):
         return [chr(i) for i in ids]
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
+        if isinstance(tokens, str):
+            # returning a single integer to be compatible with other tokenizers
+            return [ord(t) if ord(t) < 256 else 0 for t in tokens][0]
         return [ord(t) if ord(t) < 256 else 0 for t in tokens]
 
     def convert_tokens_to_string(self, tokens: list[str]):
@@ -96,8 +102,6 @@ class _SentencePieceTokenizer(BaseTokenizer):
         return self.sp_model.id_to_piece(ids)
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
-        if isinstance(tokens, str):
-            tokens = [tokens]
         return self.sp_model.piece_to_id(tokens)
 
     def convert_tokens_to_string(self, tokens: list[str]):

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -70,7 +70,7 @@ class CharTokenizer(BaseTokenizer):
         return [chr(i) for i in ids]
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
-        if isinstance(tokens, str) and len(tokens) == 1:
+        if isinstance(tokens, str):
             # returning a single integer to be compatible with other tokenizers
             token_id = ord(tokens)
             return token_id if token_id < 256 else 0

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -78,7 +78,7 @@ class CharTokenizer(BaseTokenizer):
                 )
             token_id = ord(tokens)
             return token_id if token_id < 256 else 0
-        return [ord(t) if ord(t) < 256 else 0 for t in tokens]
+        return [ord(t) if len(t) == 1 and ord(t) < 256 else 0 for t in tokens]
 
     def convert_tokens_to_string(self, tokens: list[str]):
         return "".join(tokens)

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -70,9 +70,10 @@ class CharTokenizer(BaseTokenizer):
         return [chr(i) for i in ids]
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
-        if isinstance(tokens, str):
+        if isinstance(tokens, str) and len(tokens) == 1:
             # returning a single integer to be compatible with other tokenizers
-            return [ord(t) if ord(t) < 256 else 0 for t in tokens][0]
+            token_id = ord(tokens)
+            return token_id if token_id < 256 else 0
         return [ord(t) if ord(t) < 256 else 0 for t in tokens]
 
     def convert_tokens_to_string(self, tokens: list[str]):

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -189,9 +189,7 @@ def print_result(result):
     if local_rank != 0:
         return
     # stop at EOS token if present
-    result = generation.truncate_after_eos(
-        result, tokenizer.convert_tokens_to_ids("</s>")
-    )
+    result = generation.truncate_after_eos(result, tokenizer.eos_token_id)
     # print(result)
     # print(tokenizer.convert_ids_to_tokens(result))
     print(tokenizer.convert_tokens_to_string(tokenizer.convert_ids_to_tokens(result)))

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -190,7 +190,7 @@ def print_result(result):
         return
     # stop at EOS token if present
     result = generation.truncate_after_eos(
-        result, tokenizer.convert_tokens_to_ids("</s>")
+        result, tokenizer.convert_tokens_to_ids('<\s>')
     )
     # print(result)
     # print(tokenizer.convert_ids_to_tokens(result))

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -190,7 +190,7 @@ def print_result(result):
         return
     # stop at EOS token if present
     result = generation.truncate_after_eos(
-        result, tokenizer.convert_tokens_to_ids('<\s>')
+        result, tokenizer.convert_tokens_to_ids("</s>")
     )
     # print(result)
     # print(tokenizer.convert_ids_to_tokens(result))

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -35,7 +35,7 @@ def test_text_dataset():
     assert len(ds) == 11
     first_input, _ = ds[0]
     last_input, last_label = ds[10]
-    assert last_input[0] == tokenizer.convert_tokens_to_ids("b")[0]
+    assert last_input[0] == tokenizer.convert_tokens_to_ids("b")
     expected = (["b"] * 90) + (["a"] * 9)
     torch.testing.assert_close(
         last_input, torch.tensor(tokenizer.convert_tokens_to_ids(expected))

--- a/tests/utils/test_tokenizers.py
+++ b/tests/utils/test_tokenizers.py
@@ -76,12 +76,13 @@ def test_single_token():
     # testing character tokenizer
     char_tokenizer = get_tokenizer("char_tokenizer")
     assert char_tokenizer.convert_tokens_to_ids("h") == 104
+    # multi-char strings should error with CharTokenizer
     with pytest.raises(RuntimeError):
         char_tokenizer.convert_tokens_to_ids("le")
-    assert char_tokenizer.convert_tokens_to_ids(["h", "e", "l", "l", "o"]) == [
+    assert char_tokenizer.convert_tokens_to_ids(["h", "e", "le", "l", "o"]) == [
         104,
         101,
-        108,
+        0,  # multi-char strings in lists should be output as 0 for the id
         108,
         111,
     ]

--- a/tests/utils/test_tokenizers.py
+++ b/tests/utils/test_tokenizers.py
@@ -71,12 +71,12 @@ def test_out_of_range_ascii():
 def test_single_token():
     """
     checks if convert_tokens_to_ids handles both single strings and lists. single tokens
-    should all be converted into a list of one id.
+    should all be converted into a single integer that represents the id.
     """
     # testing character tokenizer
     char_tokenizer = get_tokenizer("char_tokenizer")
-    assert char_tokenizer.convert_tokens_to_ids("h") == [104]
-    assert char_tokenizer.convert_tokens_to_ids("e") == [101]
+    assert char_tokenizer.convert_tokens_to_ids("h") == 104
+    assert char_tokenizer.convert_tokens_to_ids("e") == 101
     assert char_tokenizer.convert_tokens_to_ids(["h", "e", "l", "l", "o"]) == [
         104,
         101,
@@ -97,13 +97,23 @@ def test_single_token():
         sp = spm.SentencePieceProcessor()
         sp.load(f"{model}.model")
         sp_tokenizer = get_tokenizer(name=f"{model}.model", style="sentencepiece")
-        assert sp_tokenizer.convert_tokens_to_ids("h") == [66]
-        assert sp_tokenizer.convert_tokens_to_ids("le") == [35]
-        assert sp_tokenizer.convert_tokens_to_ids(["h", "e", "l", "l", "o", "le"]) == [
+        assert sp_tokenizer.convert_tokens_to_ids("h") == 66
+        assert sp_tokenizer.convert_tokens_to_ids("le") == 35
+        assert sp_tokenizer.convert_tokens_to_ids(["h", "e", "l", "l", "o"]) == [
             66,
             62,
             63,
             63,
             68,
-            35,
         ]
+    # testing HuggingFace tokenizer
+    hf_tokenizer = get_tokenizer("EleutherAI/gpt-neo-125M", style="hf")
+    assert hf_tokenizer.convert_tokens_to_ids("h") == 71
+    assert hf_tokenizer.convert_tokens_to_ids("le") == 293
+    assert hf_tokenizer.convert_tokens_to_ids(["h", "e", "l", "l", "o"]) == [
+        71,
+        68,
+        75,
+        75,
+        78,
+    ]

--- a/tests/utils/test_tokenizers.py
+++ b/tests/utils/test_tokenizers.py
@@ -76,7 +76,8 @@ def test_single_token():
     # testing character tokenizer
     char_tokenizer = get_tokenizer("char_tokenizer")
     assert char_tokenizer.convert_tokens_to_ids("h") == 104
-    assert char_tokenizer.convert_tokens_to_ids("e") == 101
+    with pytest.raises(RuntimeError):
+        char_tokenizer.convert_tokens_to_ids("le")
     assert char_tokenizer.convert_tokens_to_ids(["h", "e", "l", "l", "o"]) == [
         104,
         101,


### PR DESCRIPTION
bug in handling of tokens vs list of tokens #103

before the previous fix to this issue, `eos_token_id` in generation.py was expected to be an integer. `eos_token_id` is the output of the function `convert_tokens_to_ids`. the previous fix made it so that this function would instead output a list, causing the existing code to error. 

so, eos_token_id is now a list, causing `torch.where(result == eos_token_id)` in generation.py to error.

Changes:
- since SP and HF tokenizers both originally returned integers when given a single str as input, the implementation for the char tokenizer was changed to make this uniform across all three tokenizers (i.e. now the char tokenizer returns an integer instead of a list of integers when given a single str input)
- restored sentencepiece tokenizer to its original implementation in tokenizers.py
- reverted previous changes to generation.py
- added a unit test for the HF tokenizer (tests check if `convert_tokens_to_ids` returns an integer for all tokenizers)
- added to docstrings