### PR TITLE
Pin numpy<2.0 for transformers

### DIFF
--- a/hf-requirements.txt
+++ b/hf-requirements.txt
@@ -4,4 +4,5 @@
 
 -r requirements.txt
 
+numpy<2.0,>=1.17 # Needed by transformers
 transformers==4.40.2


### PR DESCRIPTION
Numpy 2.0 was released on June 16th. PyTorch 2.2 is ready for Numpy 2.0 but the transformers library is not.

Pin numpy to <2.0 in the hf-requirements so that we use the correct version of numpy when using transformers.

Note: this is needed to unlock CI!