### PR TITLE
make_padded function to support batch size > 1 with proper mask/position_ids as well as pad_to_length

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -6,25 +6,36 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-def __prepare_list_input(
-    input_ids_list: List[torch.Tensor], model: Union[Callable, torch.nn.Module]
+def make_padded(
+    input_ids_list: List[torch.Tensor], pad_to_length: Optional[int] = None
 ) -> Tuple[torch.Tensor, MutableMapping[str, Any]]:
     """
-    Convert the list of Tensors to a rectangular tensor. Return extra kwargs for the position_ids and mask, since this
-    will be required to properly handle the rectangular tensor for certain models.
+    Convert a list of Tensors to a rectangular tensor. Return extra padding kwargs for the position_ids and mask, since
+    this will be required to properly handle the rectangular tensor for certain models.
+
+    Parameters
+    ----------
+    input_ids_list: List[torch.Tensor]
+        a list of Tensors of varied length
+    pad_to_length: int, optional
+        If given, will pad to a specific max length. This value must be greater than or equal to the max length tensor.
+        (default is pad to pax tensor length)
+
+    Returns
+    -------
+    Tuple[torch.Tensor, MutableMapping[str, Any]]
+        A rectangular 2d padded tensor and a mapping containing the mask and position_ids typically used in forward pass
+        in fms models
+        A mapping from mask to a 3d causal mask and from position_ids to a 2d rectangular position_ids tensor
     """
-    min_len = min([seq.size(0) for seq in input_ids_list])
     max_len = max([seq.size(0) for seq in input_ids_list])
 
-    if isinstance(model, nn.Module):
-        forward_function = model.forward
-    else:
-        forward_function = model
-
-    params = inspect.signature(forward_function).parameters.keys()
-    extra_kwargs = {}
-    needs_mask = "mask" in params and min_len != max_len
-    needs_position_ids = "position_ids" in params and min_len != max_len
+    if pad_to_length is not None:
+        if pad_to_length < max_len:
+            raise ValueError(
+                f"pad_to_length (len={pad_to_length}) must be greater than or equal to the max length tensor (len={max_len})"
+            )
+        max_len = pad_to_length
 
     padded_input_ids_list = []
     mask_list = []
@@ -50,17 +61,16 @@ def __prepare_list_input(
         position_ids_list.append(torch.cat((pos_ids_pads, pos_ids_seq)))
 
     input_ids = torch.stack(padded_input_ids_list)
-    if needs_mask:
-        mask = torch.stack(mask_list)
-        # this is a causal mask for generation
-        mask = (mask.unsqueeze(-1) == mask.unsqueeze(-2)).tril()
-        extra_kwargs["mask"] = mask
+    padding_kwargs = {}
+    mask = torch.stack(mask_list)
+    # this is a causal mask for generation
+    mask = (mask.unsqueeze(-1) == mask.unsqueeze(-2)).tril()
+    padding_kwargs["mask"] = mask
 
-    if needs_position_ids:
-        position_ids = torch.stack(position_ids_list)
-        extra_kwargs["position_ids"] = position_ids
+    position_ids = torch.stack(position_ids_list)
+    padding_kwargs["position_ids"] = position_ids
 
-    return input_ids, extra_kwargs
+    return input_ids, padding_kwargs
 
 
 def __update_padding_kwargs(
@@ -114,7 +124,7 @@ def _make_cache_contiguous(past_key_value_states):
 
 def generate(
     model: Union[Callable, torch.nn.Module],
-    input_ids: Union[torch.Tensor, List[torch.Tensor]],
+    input_ids: torch.Tensor,
     max_seq_len: int = 4096,
     max_new_tokens: int = 256,
     temperature: float = 1.0,
@@ -124,6 +134,7 @@ def generate(
     use_cache: bool = False,
     contiguous_cache: bool = False,
     eos_token_id: Optional[int] = None,
+    extra_kwargs: Optional[MutableMapping[str, Any]] = None,
 ):
     """
     A trivial generate function that can be used for validation/testing in
@@ -135,7 +146,7 @@ def generate(
     Args:
         model: A function or nn.Module that takes a batch of input_ids and
             returns logits
-        prefix: A tensor of token IDs.
+        input_ids: a rectangular tensor of input_ids (batch x seq)
         max_seq_len: the sequence length of the model
         max_new_tokens: max tokens to generate
         temperature: temperature of softmax when sampling
@@ -144,22 +155,21 @@ def generate(
         num_beams: TODO: support beam search
         use_cache: requires that the model accept use_cache and
             past_key_value_states args in forward method.
+        eos_token_id: the optional token id representing the end of sequence
+        extra_kwargs: an optional mapping of additional kwargs to pass to the model
     """
     if num_beams != 1:
         raise NotImplementedError("generate() does yet not support beam search")
 
     kwargs: MutableMapping[str, Any] = dict()
-    # if the inputs are a tensor, we assume they are all non-pad ids and include entire context length
+    if extra_kwargs is not None:
+        kwargs.update(extra_kwargs)
+
     if isinstance(input_ids, torch.Tensor):
         is_batch = len(input_ids.shape) > 1
         # our model requires batch dimension
         if not is_batch:
             input_ids = input_ids.unsqueeze(0)
-    # if the inputs are a list, they may be made up of differently sized tensors
-    # in the case where the tensors are of different sizes, proper position ids and pads will be created
-    elif isinstance(input_ids, List):
-        is_batch = len(input_ids) > 1
-        input_ids, kwargs = __prepare_list_input(input_ids, model)
     else:
         raise TypeError("input_ids must be one of Tensor or List")
 

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -10,7 +10,7 @@ from torch import distributed as dist
 
 from fms.models import get_model
 from fms.utils import fusion, generation, tokenizers
-from fms.utils.generation import generate
+from fms.utils.generation import generate, make_padded
 
 
 # This example script validates the LLaMA implementation by running inference on a couple of prompts.
@@ -88,6 +88,12 @@ parser.add_argument(
     "--batch_input",
     action="store_true",
     help="use a batch of prompts as input",
+)
+parser.add_argument(
+    "--pad_to_length",
+    type=int,
+    help="Pad inputs to a specific length (Default is to pad to the max sequence length in batch)",
+    default=None,
 )
 parser.add_argument("--context_file", type=str, default=None, help="File to summarize")
 
@@ -184,8 +190,13 @@ max_len = max([len(prompt) for prompt in [prompt1, prompt2]])
 
 if args.batch_input:
     ids = [prompt1, prompt2]
+    ids, padding_kwargs = make_padded(ids, pad_to_length=args.pad_to_length)
 else:
     ids = prompt1
+    if args.pad_to_length is not None:
+        ids, padding_kwargs = make_padded([ids], pad_to_length=args.pad_to_length)
+    else:
+        padding_kwargs = None
 
 
 def print_result(result):
@@ -219,6 +230,7 @@ def infer(use_cache, do_sample):
         use_cache=use_cache,
         do_sample=do_sample,
         max_seq_len=max_seq_len,
+        extra_kwargs=padding_kwargs,
     )
     if len(result.shape) == 1:
         result = result.unsqueeze(0)

--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from fms.models import get_model
-from fms.utils.generation import generate, truncate_after_eos
+from fms.utils.generation import generate, make_padded, truncate_after_eos
 from fms.utils.tokenizers import get_tokenizer
 
 
@@ -83,9 +83,12 @@ def test_batched_heterogeneous():
         tokenizer.convert_tokens_to_ids(tokenizer.tokenize("CDEFGHIJKL")),
         dtype=torch.long,
     )
-    ids = [first, second]
+
     # use_cache=False
-    result = generate(_model_mock, ids, max_new_tokens=5, do_sample=False)
+    ids, padding_kwargs = make_padded([first, second])
+    result = generate(
+        _model_mock, ids, max_new_tokens=5, do_sample=False, extra_kwargs=padding_kwargs
+    )
     result1_batched = result[0]
     result2_batched = result[1]
 
@@ -96,9 +99,16 @@ def test_batched_heterogeneous():
 
     result2 = generate(_model_mock, second, max_new_tokens=5, do_sample=False)
     torch.testing.assert_close(result2, result2_batched)
+
     # use_cache=True
+    ids, padding_kwargs = make_padded([first, second])
     result = generate(
-        _model_mock, ids, max_new_tokens=5, do_sample=False, use_cache=True
+        _model_mock,
+        ids,
+        max_new_tokens=5,
+        do_sample=False,
+        use_cache=True,
+        extra_kwargs=padding_kwargs,
     )
     result1_batched = result[0]
     result2_batched = result[1]
@@ -123,3 +133,63 @@ def test_truncate():
     expected = torch.ones(11)
     expected[10] = 5
     torch.testing.assert_close(result, expected)
+
+
+def test_make_padded_bad_pad_to_length_input():
+    with pytest.raises(ValueError):
+        input_ids = [
+            torch.arange(1, 5, dtype=torch.long),
+            torch.arange(1, 10, dtype=torch.long),
+        ]
+        padded_input_ids, padding_kwargs = make_padded(input_ids, pad_to_length=3)
+
+
+def test_make_padded():
+    input_ids = [
+        torch.arange(1, 5, dtype=torch.long),
+        torch.arange(1, 10, dtype=torch.long),
+    ]
+
+    padded_input_ids, padding_kwargs = make_padded(input_ids)
+
+    expected_input_ids = torch.tensor(
+        [([0] * 5) + [i for i in range(1, 5)], [i for i in range(1, 10)]],
+        dtype=torch.long,
+    )
+
+    expected_position_ids = torch.tensor(
+        [([0] * 5) + [i for i in range(0, 4)], [i for i in range(0, 9)]],
+        dtype=torch.long,
+    )
+
+    expected_mask = torch.tensor(
+        [([0] * 5) + [1 for _ in range(0, 4)], [1 for _ in range(0, 9)]],
+        dtype=torch.bool,
+    )
+    expected_mask = (expected_mask.unsqueeze(-1) == expected_mask.unsqueeze(-2)).tril()
+
+    torch.testing.assert_close(padded_input_ids, expected_input_ids)
+    torch.testing.assert_close(padding_kwargs["position_ids"], expected_position_ids)
+    torch.testing.assert_close(padding_kwargs["mask"], expected_mask)
+
+    padded_input_ids, padding_kwargs = make_padded(input_ids, pad_to_length=64)
+
+    expected_input_ids = torch.tensor(
+        [([0] * 60) + [i for i in range(1, 5)], ([0] * 55) + [i for i in range(1, 10)]],
+        dtype=torch.long,
+    )
+
+    expected_position_ids = torch.tensor(
+        [([0] * 60) + [i for i in range(0, 4)], ([0] * 55) + [i for i in range(0, 9)]],
+        dtype=torch.long,
+    )
+
+    expected_mask = torch.tensor(
+        [([0] * 60) + [1 for _ in range(0, 4)], ([0] * 55) + [1 for _ in range(0, 9)]],
+        dtype=torch.bool,
+    )
+    expected_mask = (expected_mask.unsqueeze(-1) == expected_mask.unsqueeze(-2)).tril()
+
+    torch.testing.assert_close(padded_input_ids, expected_input_ids)
+    torch.testing.assert_close(padding_kwargs["position_ids"], expected_position_ids)
+    torch.testing.assert_close(padding_kwargs["mask"], expected_mask)


### PR DESCRIPTION
Currently, padding and masking occurs in the generate function. This function will move that logic out of the generate function and make it a regular utility to used alongside generation. This function will also include the ability to pad to a max length. The inference script now also has the option to pad_to_length (for both single prompt and batch size > 1)

Usage:

```python
padded_input_ids, padding_kwargs = make_padded(input_ids_list, pad_to_length=64)
```