### PR TITLE
Minimal implementation of muP scaling for Llama

### DIFF
--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -57,11 +57,12 @@ class LLaMAConfig(ModelConfig):
     # muP values
     #   - Comments are: Left, our formula, Right, target
     #   - Values calculated based on TinyLlama
-    mup_emb_scale: float = .02  # 1 * f  =  0.02
-    mup_head_scale: float = 20.48  # 1/sqrt(d) * f  =  .02 * sqrt(d)
+    mup_emb_scale: float = .03125  # sqrt(d) * f  =  1
+    mup_head_scale: float = 32.0  # 1/sqrt(d) * f  =  1
+    mup_1d_init: float = .640  # 1/sqrt(d) * f = 0.02
     mup_ffn_init: float = .7575  # 1/sqrt(d) / 6rt(multiple_of_growf) * f  =  .02
     mup_attn_init: float = .640  # 1/sqrt(d) / 4rt(emb_v * nheads / d) * f  =  .02
-    mup_attn_temp: float = 32  # 1/d * f  =  1/sqrt(d)
+    mup_attn_temp: float = 32.0  # 1/d * f  =  1/sqrt(d)
     
     # muP LRs
     mup_0d_lr: float = .001  # f  =  .001
@@ -260,7 +261,13 @@ class LLaMA(nn.Module):
                 m.reset_parameters(scale = self.config.mup_ffn_init)
             elif isinstance(m, QKV):
                 m.reset_parameters(scale = self.config.mup_attn_init)
-            elif isinstance(m, WordEmbedding) or isinstance(m, LayerNormParameterized):
+            elif isinstance(m, WordEmbedding):
+                m.reset_parameters(scale = (
+                    self.config.mup_1d_init, 
+                    self.config.mup_emb_scale, 
+                    self.config.mup_head_scale,
+                ))
+            elif isinstance(m, LayerNormParameterized):
                 m.reset_parameters()
 
     def validate_reset_parameters(self):

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -108,6 +108,7 @@ class LLaMABlock(nn.Module):
             p_dropout=self.config.p_dropout,
             use_bias=self.config.attn_bias,
             position_encoder=rotary_emb,
+            attn_scale=self.config.mup_attn_temp,
         )
         self.ff_sub_layer = GatedLinearUnit(
             self.config.emb_dim,
@@ -253,12 +254,11 @@ class LLaMA(nn.Module):
     def reset_parameters(self):
         # Call reset_parameters for relevant sub-layers
         for m in self.modules():
-            if (
-                isinstance(m, MultiHeadAttention)
-                or isinstance(m, WordEmbedding)
-                or isinstance(m, GatedLinearUnit)
-                or isinstance(m, LayerNormParameterized)
-            ):
+            if isinstance(m, MultiHeadAttention):
+                m.reset_parameters(scale = self.config.mup_attn_init)
+            elif isinstance(m, GatedLinearUnit):
+                m.reset_parameters(scale = self.config.mup_ffn_init)
+            elif isinstance(m, WordEmbedding) or isinstance(m, LayerNormParameterized):
                 m.reset_parameters()
 
     def validate_reset_parameters(self):

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -53,6 +53,20 @@ class LLaMAConfig(ModelConfig):
     attn_bias: bool = False
     mlp_bias: bool = False
     tie_heads: bool = False
+    
+    # muP values
+    #   - Comments are: Left, our formula, Right, target
+    #   - Values calculated based on TinyLlama
+    mup_emb_scale: float = .02  # 1 * f  =  0.02
+    mup_head_scale: float = 20.48  # 1/sqrt(d) * f  =  .02 * sqrt(d)
+    mup_ffn_init: float = .7575  # 1/sqrt(d) / 6rt(multiple_of_growf) * f  =  .02
+    mup_attn_init: float = .640  # 1/sqrt(d) / 4rt(emb_v * nheads / d) * f  =  .02
+    mup_attn_temp: float = 32  # 1/d * f  =  1/sqrt(d)
+    
+    # muP LRs
+    mup_0d_lr: float = .001  # f  =  .001
+    mup_1d_lr: float = .032  # 1/sqrt(d) * f  =  .001
+    mup_2d_lr: float = 1.024  # 1/d * f = .001
 
 
 class LLaMABlock(nn.Module):

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -17,7 +17,7 @@ from fms.distributed.strategy import (
     TensorParallelStrategy,
     UniformModelParallelStrategy,
 )
-from fms.modules.attention import MultiHeadAttention
+from fms.modules.attention import MultiHeadAttention, QKV
 from fms.modules.embedding import WordEmbedding
 from fms.modules.feedforward import GatedLinearUnit
 from fms.modules.layernorm import LayerNormParameterized
@@ -258,6 +258,8 @@ class LLaMA(nn.Module):
                 m.reset_parameters(scale = self.config.mup_attn_init)
             elif isinstance(m, GatedLinearUnit):
                 m.reset_parameters(scale = self.config.mup_ffn_init)
+            elif isinstance(m, QKV):
+                m.reset_parameters(scale = self.config.mup_attn_init)
             elif isinstance(m, WordEmbedding) or isinstance(m, LayerNormParameterized):
                 m.reset_parameters()
 

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -58,16 +58,6 @@ class QKV(nn.Module, metaclass=abc.ABCMeta):
         """
         pass
 
-    @abc.abstractmethod
-    def reset_parameters(self):
-        """resets the query, key, and value weights for training
-
-        Args:
-            gain: int
-                gain for std in norm (default is 1)
-        """
-        pass
-
 
 class UnfusedQKV(QKV):
     """
@@ -104,13 +94,6 @@ class UnfusedQKV(QKV):
         self.value = nn.Linear(
             self.emb_dim, self.kvheads * self.emb_v_per_head, bias=use_bias
         )
-
-    def reset_parameters(self):
-        for m in self.modules():
-            if isinstance(m, nn.Linear):
-                nn.init.trunc_normal_(m.weight, mean=0.0, std=0.02)
-                if self.use_bias:
-                    m.bias.data.zero_()
 
     def forward(
         self, q: torch.Tensor, k: Optional[torch.Tensor], v: Optional[torch.Tensor]
@@ -190,11 +173,6 @@ class FusedQKV(QKV):
             result.value.bias.copy_(value_bias)
         return result
 
-    def reset_parameters(self):
-        nn.init.trunc_normal_(self.qkv_fused.weight, mean=0.0, std=0.02)
-        if self.use_bias:
-            self.qkv_fused.bias.data.zero_()
-
     def forward(
         self, q: torch.Tensor, k: Optional[torch.Tensor], v: Optional[torch.Tensor]
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -238,6 +216,7 @@ class MultiHeadAttention(nn.Module):
         use_bias=False,
         position_encoder: Optional[PositionEncoder] = None,
         fused: bool = True,
+        attn_scale: float = 1
     ):
         super(MultiHeadAttention, self).__init__()
         self.nheads = nheads
@@ -248,6 +227,7 @@ class MultiHeadAttention(nn.Module):
         self.p_dropout = p_dropout if p_dropout is not None else 0.0
         self.use_bias = use_bias
         self.fused = fused
+        self.attn_scale = attn_scale
 
         self.in_proj: QKV = (FusedQKV if self.fused else UnfusedQKV)(
             self.emb_dim,
@@ -271,14 +251,16 @@ class MultiHeadAttention(nn.Module):
         )
         self.previous_math: bool = torch.backends.cuda.math_sdp_enabled()
 
-    def reset_parameters(self):
+    def reset_parameters(self, scale=1):
         for m in self.modules():
             if isinstance(m, nn.Linear):
-                nn.init.trunc_normal_(m.weight, mean=0.0, std=0.02)
+                nn.init.normal_(
+                    m.weight, 
+                    mean=0.0, 
+                    std=scale / self.emb_dim**.5 / (self.nheads * self.emb_v_per_head / self.emb_dim)**.25,
+                )
                 if self.use_bias:
                     m.bias.data.zero_()
-            elif isinstance(m, QKV):
-                m.reset_parameters()
 
     def to_tp(self, group: ProcessGroup) -> "TPMultiHeadAttention":
         return TPMultiHeadAttention.import_module(self, group)
@@ -288,10 +270,10 @@ class MultiHeadAttention(nn.Module):
         q: torch.Tensor,
         k: Optional[torch.Tensor] = None,
         v: Optional[torch.Tensor] = None,
-        mask: Optional[Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
         position_ids=None,
         attn_algorithm=None,
-        past_key_value_state: Optional[Tuple[Tensor, Tensor]] = None,
+        past_key_value_state: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
         use_cache=False,
         is_self=True,
         is_causal_mask=False,
@@ -400,6 +382,7 @@ class MultiHeadAttention(nn.Module):
             attn_mask=attn_mask,
             dropout_p=self.p_dropout if self.training else 0.0,
             is_causal=is_causal_mask,
+            scale=self.attn_scale / self.emb_kq_per_head,
         )
 
         if attn_algorithm:

--- a/fms/modules/embedding.py
+++ b/fms/modules/embedding.py
@@ -90,7 +90,7 @@ class WordEmbedding(nn.Module):
         if self.reversible and not self.tie_weights:
             layers.append("head")
         for layer in layers:
-            nn.init.trunc_normal_(getattr(self, layer).weight, mean=0.0, std=0.02)
+            nn.init.normal_(getattr(self, layer).weight, mean=0.0, std=0.02)
         if self.reversible and self.bias:
             self.head.bias.data.zero_()
         # Preserve pad index dummy-hood

--- a/fms/modules/embedding.py
+++ b/fms/modules/embedding.py
@@ -82,7 +82,7 @@ class WordEmbedding(nn.Module):
             if tie_weights:
                 self.head.weight = self.emb.weight
 
-    def reset_parameters(self):
+    def reset_parameters(self, scale=1):
         # Defaults to norm-preserving in reverse op, unit vector in forward op
         layers = ["emb"]
         if self.abs_pos:

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -217,7 +217,7 @@ class GatedLinearUnit(nn.Module):
 
     def reset_parameters(self, scale=1):
         for layer in ["wg1_fused", "w2"]:
-            nn.init.trunc_normal_(
+            nn.init.normal_(
                 getattr(self, layer).weight,
                 mean=0.0,
                 std=scale / (self.width**.5) / (self.hidden_dim/self.width)**(1/6),

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -215,12 +215,12 @@ class GatedLinearUnit(nn.Module):
         self.width = emb_dim
         self.grow_factor = hidden_grow_factor
 
-    def reset_parameters(self):
+    def reset_parameters(self, scale=1):
         for layer in ["wg1_fused", "w2"]:
             nn.init.trunc_normal_(
                 getattr(self, layer).weight,
                 mean=0.0,
-                std=0.02,
+                std=scale / (self.width**.5) / (self.hidden_dim/self.width)**(1/6),
             )
             if self.use_bias:
                 getattr(self, layer).bias.data.zero_()

--- a/fms/modules/layernorm.py
+++ b/fms/modules/layernorm.py
@@ -50,7 +50,7 @@ class LayerNormParameterized(nn.Module):
         # else:
         #     self.register_parameter("bias", None)
 
-    def reset_parameters(self):
+    def reset_parameters(self, scale=1):
         if self.elementwise_scale:
             self.weight.data.fill_(1)
         if self.elementwise_shift:


### PR DESCRIPTION
Implement [muP scaling](https://arxiv.org/abs/2203.03466) for Llama models. Model follows muP scaling laws but introduces the minimal set of extra tunable hyperparameters that allows us to recover prior behavior - thus may not be compatible (yet) with existing muP configs. 

- Introduce extra muP params to Llama config
- Calculate base values that allow us to mimic the training behavior of default Llama-194M config
- Swap out `trunc_normal_ init` for `normal_` (redundant without specifying the clamp values, plus we noticed some FSDP-related issues in the speculator setting)
- Adjust `reset_parameters` so that each module initializes itself but no submodules (following FSDP init_fn contract)