### PR TITLE
update eval_harness.py to reflect updates to lm_eval package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 # Useful for dev/test jobs caches
 # Must be kept in sync with setup.py
 torch == 2.2.0 # This is what is installed in CI today
-lm-eval == 0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # Useful for dev/test jobs caches
 # Must be kept in sync with setup.py
 torch == 2.2.0 # This is what is installed in CI today
+lm-eval == 0.4.2

--- a/scripts/eval_harness.py
+++ b/scripts/eval_harness.py
@@ -143,8 +143,6 @@ if args.compile:
 
 lm_obj = evaluation.FMSEvalHarnessLM(model=model, tokenizer=tokenizer, device=device)
 
-lm_eval.tasks.initialize_tasks()
-
 results = lm_eval.simple_evaluate(
     model=lm_obj,
     tasks=args.tasks.split(","),

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,4 +14,4 @@ pyarrow-stubs==10.0.1.7
 types-requests==2.31.0.20240125
 
 # Model testing
-lm_eval==0.4.1
+lm_eval==0.4.2


### PR DESCRIPTION
`scripts/eval_harness.py` does not work with the most recent version of lm_eval. the proposed change would make this script compatible with lm_eval == v0.4.2.

Fixes bug to reflect changes to lm-eval's general API. Call to `lm_eval.tasks.include_path()` is no longer needed according to v0.4.2: https://github.com/EleutherAI/lm-evaluation-harness/releases. 

This PR reflects this change in implementation and updates requirements.txt to use a more recent version of lm-eval.