### PR TITLE
Add post iteration hook to generation

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Any, Callable, List, MutableMapping, Optional, Tuple, Union
 
@@ -230,7 +229,6 @@ def generate(
         else:
             next_val = torch.argmax(logits, dim=-1).unsqueeze(0).t()
 
-        # Golden reference replacement
         if post_iteration_hook is not None:
             next_val, kwargs = post_iteration_hook(logits, next_val, kwargs)
 


### PR DESCRIPTION
This PR adds a per-iteration hook to the generate() function.

One use-case for this function is adding debug information or running some kind of validation that requires more information about the status of the loop compared to what you get at the end of the generation loop.

For example, a use-case for this hook is to compare the logits being outputed by the model to some reference logits from another model implementation or the model running on another device.

The return values allow for the function to change the next token being added to the sequence or modify the kwargs being sent to the model for the next iteration.