### PR TITLE
set_input_embeddings implementation for HFAdaptedLLaMADecoder to enable resize_token_embeddings

### DIFF
--- a/fms/models/hf/llama/modeling_llama_hf.py
+++ b/fms/models/hf/llama/modeling_llama_hf.py
@@ -17,6 +17,9 @@ class HFAdaptedLLaMADecoder(HFDecoder):
     def __init__(self, model: LLaMA, config: PretrainedConfig):
         super().__init__(model, config, attention_mask_dim=3)
 
+    def set_input_embeddings(self, value: nn.Module):
+        self.model.shared.emb = value
+
     def _adapt(
         self,
         input_ids: Optional[torch.LongTensor] = None,


### PR DESCRIPTION
Currently, if a user wants to call `set_input_embeddings`, they do not have this option as it's not implemented for HFAdaptedLLaMADecoder. This PR adds that implementation.