### PR TITLE
fix: python 3.8 list tokenizer.py

### DIFF
--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -39,14 +39,14 @@ class BaseTokenizer:
     def convert_ids_to_tokens(self, ids: torch.LongTensor):
         raise NotImplementedError
 
-    def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
+    def convert_tokens_to_ids(self, tokens: Union[str, List[str]]):
         """
         for all tokenizers, a str parameter will be interpreted as a single token,
         and its output will be a single integer that represents the id.
         """
         raise NotImplementedError
 
-    def convert_tokens_to_string(self, tokens: list[str]):
+    def convert_tokens_to_string(self, tokens: List[str]):
         raise NotImplementedError
 
     def vocab_size(self) -> int:
@@ -69,7 +69,7 @@ class CharTokenizer(BaseTokenizer):
     def convert_ids_to_tokens(self, ids: torch.LongTensor):
         return [chr(i) for i in ids]
 
-    def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
+    def convert_tokens_to_ids(self, tokens: Union[str, List[str]]):
         if isinstance(tokens, str):
             # returning a single integer to be compatible with other tokenizers
             if len(tokens) != 1:
@@ -80,7 +80,7 @@ class CharTokenizer(BaseTokenizer):
             return token_id if token_id < 256 else 0
         return [ord(t) if len(t) == 1 and ord(t) < 256 else 0 for t in tokens]
 
-    def convert_tokens_to_string(self, tokens: list[str]):
+    def convert_tokens_to_string(self, tokens: List[str]):
         return "".join(tokens)
 
     def vocab_size(self):
@@ -106,10 +106,10 @@ class _SentencePieceTokenizer(BaseTokenizer):
             ids = ids.tolist()
         return self.sp_model.id_to_piece(ids)
 
-    def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
+    def convert_tokens_to_ids(self, tokens: Union[str, List[str]]):
         return self.sp_model.piece_to_id(tokens)
 
-    def convert_tokens_to_string(self, tokens: list[str]):
+    def convert_tokens_to_string(self, tokens: List[str]):
         return self.sp_model.decode(tokens)
 
     def vocab_size(self):
@@ -133,10 +133,10 @@ class _HFTokenizer(BaseTokenizer):
     def convert_ids_to_tokens(self, ids: torch.LongTensor):
         return self.tokenizer.convert_ids_to_tokens(ids)
 
-    def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
+    def convert_tokens_to_ids(self, tokens: Union[str, List[str]]):
         return self.tokenizer.convert_tokens_to_ids(tokens)
 
-    def convert_tokens_to_string(self, tokens: list[str]):
+    def convert_tokens_to_string(self, tokens: List[str]):
         return self.tokenizer.convert_tokens_to_string(tokens)
 
     def vocab_size(self):


### PR DESCRIPTION
Some AI Accelerator vendors unfortunately support python 3.8 in their nightly pytorch builds :(

fixes this repo for python 3.8