### PR TITLE
Fixed inefficiency in SDPA when using padding_kwargs

### DIFF
--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -430,6 +430,9 @@ class MultiHeadAttention(nn.Module):
             torch.backends.cuda.enable_mem_efficient_sdp(use_mem_efficient)
             torch.backends.cuda.enable_math_sdp(use_math)
 
+        if attn_mask is not None:
+            attn_mask = attn_mask.to(dtype=queries.dtype)
+
         attn = F.scaled_dot_product_attention(
             queries,
             keys_e,

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -430,7 +430,7 @@ class MultiHeadAttention(nn.Module):
             torch.backends.cuda.enable_mem_efficient_sdp(use_mem_efficient)
             torch.backends.cuda.enable_math_sdp(use_math)
 
-        if attn_mask is not None:
+        if attn_mask is not None and attn_mask.dtype != torch.bool:
             attn_mask = attn_mask.to(dtype=queries.dtype)
 
         attn = F.scaled_dot_product_attention(

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -57,6 +57,7 @@ def pad_input_ids(
     mask = torch.stack(mask_list)
     # this is a causal mask for generation
     mask = (mask.unsqueeze(-1) == mask.unsqueeze(-2)).tril()
+    mask = torch.where(mask.logical_not(), -torch.inf, 0.0)
     padding_kwargs["mask"] = mask
 
     position_ids = torch.stack(position_ids_list)
@@ -78,7 +79,7 @@ def __update_padding_kwargs(
         mask = torch.cat(
             (
                 mask,
-                torch.ones(mask.size(0), 1, 1, dtype=torch.bool, device=mask.device),
+                torch.zeros(mask.size(0), 1, 1, device=mask.device),
             ),
             dim=2,
         )

--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -165,10 +165,11 @@ def test_pad_input_ids():
     )
 
     expected_mask = torch.tensor(
-        [([0] * 5) + [1 for _ in range(0, 4)], [1 for _ in range(0, 9)]],
+        [([1] * 5) + [0 for _ in range(0, 4)], [0 for _ in range(0, 9)]],
         dtype=torch.bool,
     )
     expected_mask = (expected_mask.unsqueeze(-1) == expected_mask.unsqueeze(-2)).tril()
+    expected_mask = torch.where(expected_mask.logical_not(), -torch.inf, 0.0)
 
     torch.testing.assert_close(padded_input_ids, expected_input_ids)
     torch.testing.assert_close(padding_kwargs["position_ids"], expected_position_ids)
@@ -187,10 +188,11 @@ def test_pad_input_ids():
     )
 
     expected_mask = torch.tensor(
-        [([0] * 60) + [1 for _ in range(0, 4)], ([0] * 55) + [1 for _ in range(0, 9)]],
+        [([1] * 60) + [0 for _ in range(0, 4)], ([1] * 55) + [0 for _ in range(0, 9)]],
         dtype=torch.bool,
     )
     expected_mask = (expected_mask.unsqueeze(-1) == expected_mask.unsqueeze(-2)).tril()
+    expected_mask = torch.where(expected_mask.logical_not(), -torch.inf, 0.0)
 
     torch.testing.assert_close(padded_input_ids, expected_input_ids)
     torch.testing.assert_close(padding_kwargs["position_ids"], expected_position_ids)


### PR DESCRIPTION
Currently SDPA favors an additive mask. In this PR, we remove the boolean mask in favor of an additive mask