### PR TITLE
Improve `hf_pretrained` API for local HF models

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -120,8 +120,7 @@ def __maybe_infer_model_variant(
         variant = extra_kwargs.pop("variant")
 
         if is_hf_pretrained:
-            if is_hf_pretrained:
-                model_path = extra_kwargs.pop("model_path")
+            model_path = extra_kwargs.pop("model_path")
             source = "hf"
         else:
             extra_kwargs = {**extra_kwargs, **kwargs}
@@ -339,11 +338,12 @@ def get_model(
     Args:
     architecture: the model architecture, e.g. llama. See
                 `models.list_models()`. If hf_pretrained is given, the model architecture will be inferred by the
-                model_config associated with the hf model_id_or_path and subsequently the weights will be downloaded and
-                loaded into the model. If hf_configured is given, only the model architecture configuration will be and
-                no weights will explicitly be loaded unless following the normal model_path logic. Note, if
-                hf_pretrained is given and model_path or source are set, an exception will be raised as model loading
-                will occur through the hf cache.
+                model_config associated with either the HF model name (e.g. meta-llama/Llama-3.1-8B, passed as `variant` here),
+                or the local path (e.g. /home/fms/models/llama3.1-8b/, passed as `model_path`). If the model architecture is passed
+                through the `variant`, the weights will be loaded from the local HF cache if available, or downloaded otherwise.
+                If hf_configured is given, only the model architecture configuration will be loaded from the HF model name (`variant`)
+                and no weights will explicitly be loaded unless following the normal model_path logic. Note, if hf_pretrained is given
+                and source is set, an exception will be raised as model loading will always be from a HF checkpoint.
     variant: the configuration of the model, e.g. 7b. See
                 `models.list_variants(architecture)`. If architecture is given as "hf_pretrained" or "hf_configured",
                 the variant will refer to the hf model_id_or_path.

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -97,7 +97,7 @@ def __maybe_infer_model_variant(
                 raise ValueError(
                     """
                     architecture="hf_pretrained" implies one of two things: 
-                    1. if variant is defined, model config and weights will be downloaded and extracted from hf cache and loaded into the model, therefore model_path should not be set.
+                    1. if variant is defined, model config and weights will be downloaded if not present, then extracted from hf cache, and finally loaded into the model, therefore model_path should not be set.
                     2. if model_path is defined, model config and weights will be loaded from model_path, therefore variant should not be set.
                     In both cases, source should not be set.
                     """

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -93,7 +93,7 @@ def __maybe_infer_model_variant(
                 required_args = [variant]
                 banned_args = [model_path, source]
             if is_hf_configured:
-                required_args = [variant, model_path, source]
+                required_args = [variant, model_path]
                 banned_args = []
         elif architecture == "hf_inferred":
             logger.info(f"inferring model configuration from {model_path}")

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -92,6 +92,10 @@ def __maybe_infer_model_variant(
                 raise ValueError(
                     """architecture="hf_pretrained" implies model weights will be downloaded and extracted from hf cache and loaded into the model, therefore model_path and source should not be set"""
                 )
+            if is_hf_inferred and model_path is None:
+                raise ValueError(
+                    """architecture="hf_inferred" implies model config and weights are loaded from model_path, therefore it should be set"""
+                )
             if len(kwargs) > 0:
                 logger.warning(
                     f"ignoring the following parameters as a pretrained model with an inferred configuration is being loaded: {list(kwargs.keys())}"

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -93,7 +93,7 @@ def __maybe_infer_model_variant(
             model_path_or_variant = variant
 
         if is_hf_pretrained:
-            if (variant is None == model_path is None) or source is not None:
+            if ((variant is None) == (model_path is None)) or source is not None:
                 raise ValueError(
                     """
                     architecture="hf_pretrained" implies one of two things: 
@@ -106,9 +106,9 @@ def __maybe_infer_model_variant(
                 logger.warning(
                     f"ignoring the following parameters as a pretrained model with an inferred configuration is being loaded: {list(kwargs.keys())}"
                 )
-        if is_hf_configured and (variant is None or model_path is None):
+        if is_hf_configured and variant is None:
             raise ValueError(
-                """architecture="hf_configured" implies model config is loaded from variant and weights are loaded from model_path, therefore both should be set"""
+                """architecture="hf_configured" implies model config is loaded from variant, therefore it should be set"""
             )
 
         logger.info(f"inferring model configuration from {model_path_or_variant}")


### PR DESCRIPTION
This PR adds the option for `hf_pretrained` to take either a `variant` or a `model_path` to infer the configuration and load the weights of a model. This covers the case of HF checkpoints of models not yet available in the Hub, which neither of `hf_pretrained` or `hf_configured` were covering before.

cc @tdoublep