### PR TITLE
Add only_last_token to GPTBigCode model to match other APIs

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -95,11 +95,12 @@ def __maybe_infer_model_variant(
         if is_hf_pretrained:
             if ((variant is None) == (model_path is None)) or source is not None:
                 raise ValueError(
-                    """
+                    f"""
                     architecture="hf_pretrained" implies one of two things: 
                     1. if variant is defined, model config and weights will be downloaded if not present, then extracted from hf cache, and finally loaded into the model, therefore model_path should not be set.
                     2. if model_path is defined, model config and weights will be loaded from model_path, therefore variant should not be set.
                     In both cases, source should not be set.
+                    Your values are: variant - {variant}; model_path - {model_path}; source - {source}
                     """
                 )
             if len(kwargs) > 0:

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -330,10 +330,10 @@ class GPTBigCode(nn.Module):
 
     def forward(
         self,
-        x: torch.LongTensor,
+        x: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_value_states: Optional[Tuple[torch.FloatTensor,]] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_value_states: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
         use_cache: bool = False,
         only_last_token: bool = False,
         attn_algorithm: Optional[str] = None,

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -335,6 +335,7 @@ class GPTBigCode(nn.Module):
         position_ids: Optional[torch.LongTensor] = None,
         past_key_value_states: Optional[Tuple[torch.FloatTensor,]] = None,
         use_cache: bool = False,
+        only_last_token: bool = False,
         attn_algorithm: Optional[str] = None,
     ):
         output, cache = self.base_model(
@@ -346,6 +347,8 @@ class GPTBigCode(nn.Module):
             attn_algorithm=attn_algorithm,
         )
 
+        if only_last_token:
+            output = output[:, -1, :]
         preds = self.head(output)
 
         if use_cache:

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -400,13 +400,15 @@ class LLaMA(nn.Module):
 
     def forward(
         self,
-        x,
-        mask=None,
-        position_ids=None,
-        past_key_value_states=None,
-        use_cache=False,
-        only_last_token=False,
-        attn_algorithm=None,
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_value_states: Optional[
+            List[Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]
+        ] = None,
+        use_cache: bool = False,
+        only_last_token: bool = False,
+        attn_algorithm: Optional[str] = None,
     ):
         output, cache = self._helper(
             x, mask, position_ids, past_key_value_states, use_cache, attn_algorithm

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -403,9 +403,7 @@ class LLaMA(nn.Module):
         x: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
-        past_key_value_states: Optional[
-            List[Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]
-        ] = None,
+        past_key_value_states: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
         use_cache: bool = False,
         only_last_token: bool = False,
         attn_algorithm: Optional[str] = None,

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -220,7 +220,9 @@ def generate(
                 kwargs["past_key_value_states"] = past_key_value_states
         else:
             logits = output
-        logits = logits[:, -1, :]
+
+        if not "only_last_token" in kwargs:
+            logits = logits[:, -1, :]
 
         if do_sample:
             # get logits from last value in sequence nad scale


### PR DESCRIPTION
This PR adds the missing `only_last_token` to GPTBigCode models to match Llama and Mixtral APIs.