### PR TITLE
Support different mask types from pad_input_ids

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -6,7 +6,9 @@ import torch.nn.functional as F
 
 
 def pad_input_ids(
-    input_ids_list: List[torch.Tensor], min_pad_length: int = 0
+    input_ids_list: List[torch.Tensor],
+    min_pad_length: int = 0,
+    mask_dtype: Optional[Union[torch.dtype | str]] = None,
 ) -> Tuple[torch.Tensor, MutableMapping[str, Any]]:
     """
     Convert a list of Tensors to a rectangular tensor. Return extra padding kwargs for the position_ids and mask, since
@@ -19,6 +21,8 @@ def pad_input_ids(
     min_pad_length: int
         pad to a min length provided. If the min_pad_length is less than the largest input_ids in the input_ids_list,
         padding will be determined based on the largest length input_ids.
+    mask_dtype: Optional[Union[torch.dtype | str]]
+        optionally set a mask dtype. By default, the mask will be set to the default tensor type
 
     Returns
     -------
@@ -57,7 +61,18 @@ def pad_input_ids(
     mask = torch.stack(mask_list)
     # this is a causal mask for generation
     mask = (mask.unsqueeze(-1) == mask.unsqueeze(-2)).tril()
-    mask = torch.where(mask.logical_not(), -torch.inf, 0.0)
+
+    if mask_dtype is None:
+        mask_dtype = torch.get_default_dtype()
+    else:
+        mask_dtype = (
+            mask_dtype
+            if isinstance(mask_dtype, torch.dtype)
+            else getattr(torch, mask_dtype)
+        )
+
+    if mask_dtype != torch.bool:
+        mask = torch.where(mask.logical_not(), -torch.inf, 0.0)
     padding_kwargs["mask"] = mask
 
     position_ids = torch.stack(position_ids_list)
@@ -75,11 +90,14 @@ def __update_padding_kwargs(
     if mask is not None:
         # get the last row of the 3d mask
         mask = mask[:, -1:, :]
+
+        mask_pad_fn = torch.ones if mask.dtype == torch.bool else torch.zeros
+
         # extend the mask one slot
         mask = torch.cat(
             (
                 mask,
-                torch.zeros(mask.size(0), 1, 1, device=mask.device),
+                mask_pad_fn(mask.size(0), 1, 1, dtype=mask.dtype, device=mask.device),
             ),
             dim=2,
         )

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -96,6 +96,9 @@ parser.add_argument(
     default=0,
 )
 parser.add_argument("--context_file", type=str, default=None, help="File to summarize")
+parser.add_argument(
+    "--mask_dtype", type=str, default=None, choices=["float16", "float32", "bool"]
+)
 
 args = parser.parse_args()
 
@@ -187,14 +190,18 @@ prompt1 = ids_for_prompt(prompt1)
 prompt2 = ids_for_prompt(prompt2)
 max_len = max([len(prompt) for prompt in [prompt1, prompt2]])
 
-
+mask_dtype = args.mask_dtype
 if args.batch_input:
     ids = [prompt1, prompt2]
-    ids, padding_kwargs = pad_input_ids(ids, min_pad_length=args.min_pad_length)
+    ids, padding_kwargs = pad_input_ids(
+        ids, min_pad_length=args.min_pad_length, mask_dtype=mask_dtype
+    )
 else:
     ids = prompt1
     if args.min_pad_length != 0:
-        ids, padding_kwargs = pad_input_ids([ids], min_pad_length=args.min_pad_length)
+        ids, padding_kwargs = pad_input_ids(
+            [ids], min_pad_length=args.min_pad_length, mask_dtype=mask_dtype
+        )
     else:
         padding_kwargs = None
 


### PR DESCRIPTION
Currently, `pad_input_ids` assumes an additive mask as this is most efficient in sdpa (no conversion required), however some may want a boolean mask. This PR addresses this issue