### PR TITLE
Fix GPTQ llama adapter for granite-8b

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -96,7 +96,7 @@ def __maybe_infer_model_variant(
             if ((variant is None) == (model_path is None)) or source is not None:
                 raise ValueError(
                     f"""
-                    architecture="hf_pretrained" implies one of two things: 
+                    architecture="hf_pretrained" implies one of two things:
                     1. if variant is defined, model config and weights will be downloaded if not present, then extracted from hf cache, and finally loaded into the model, therefore model_path should not be set.
                     2. if model_path is defined, model config and weights will be loaded from model_path, therefore variant should not be set.
                     In both cases, source should not be set.
@@ -393,7 +393,7 @@ def get_model(
 
     is_gptq = (
         extra_args.get("linear_config", None)
-        and extra_args["linear_config"].get("linear_type", None) == "gptq"
+        and "gptq" in extra_args["linear_config"].get("linear_type", None)
     )
 
     hsdp = distributed_strategy == "hsdp"
@@ -445,11 +445,11 @@ def get_model(
         _validate_unfuse_strategy(extra_args, rank)
 
         # change source for "gptq + pre" (= unfused gptq ckpt into unfused model)
-        if is_gptq and extra_args.get("unfuse_strategy") == "pre":
-            if source != "hf":  # GPTQ ckpt is always "hf" style
-                raise ValueError(
-                    f"Expected GPTQ checkpoint of type `hf` but source is `{source}` instead"
-                )
+        if (
+            is_gptq
+            and extra_args.get("unfuse_strategy") == "pre"
+            and source == "hf"
+        ):
             source = "gptq_" + source + "_unfused"
 
     # Create the model on meta device to allocate weights lazily

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -391,10 +391,9 @@ def get_model(
     else:
         data_type_parsed = data_type
 
-    is_gptq = (
-        extra_args.get("linear_config", None)
-        and "gptq" in extra_args["linear_config"].get("linear_type", None)
-    )
+    is_gptq = extra_args.get("linear_config", None) and "gptq" in extra_args[
+        "linear_config"
+    ].get("linear_type", None)
 
     hsdp = distributed_strategy == "hsdp"
     fsdp = distributed_strategy == "fsdp"
@@ -445,11 +444,7 @@ def get_model(
         _validate_unfuse_strategy(extra_args, rank)
 
         # change source for "gptq + pre" (= unfused gptq ckpt into unfused model)
-        if (
-            is_gptq
-            and extra_args.get("unfuse_strategy") == "pre"
-            and source == "hf"
-        ):
+        if is_gptq and extra_args.get("unfuse_strategy") == "pre" and source == "hf":
             source = "gptq_" + source + "_unfused"
 
     # Create the model on meta device to allocate weights lazily

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -682,7 +682,7 @@ def _hf_unfused_sd_to_fms_unfused_sd(hf_sd: Mapping) -> Mapping:
 # TODO: merge with standard _hf_sd_to_fms_sd adapter
 # Very similar except:
 # 1) add in_proj to q,k,v
-# 2) qparams to transpose are qweight|scales|qzeros (not weight|bias)
+# 2) qparams to transpose are qweight|scales|qzeros|bias (not weight)
 # 3) fully transpose params before & after processing
 def _gptq_unfused_sd_to_fms_unfused_sd(hf_sd: Mapping) -> Mapping:
     replacements = [
@@ -702,7 +702,7 @@ def _gptq_unfused_sd_to_fms_unfused_sd(hf_sd: Mapping) -> Mapping:
     ]
     fms_unfused_sd = {}
     trans_required_pattern = re.compile(
-        "layers.[0-9]+.attn.in_proj.(query|key).(qweight|scales|qzeros)"
+        "layers.[0-9]+.attn.in_proj.(query|key).(qweight|scales|qzeros|bias)"
     )
     for hf_name, param in hf_sd.items():
         fms_name = hf_name
@@ -714,25 +714,28 @@ def _gptq_unfused_sd_to_fms_unfused_sd(hf_sd: Mapping) -> Mapping:
         # weight and bias parameters
         # Differently from hf-to-fms conversion, GPTQ qweights are [in_feat, out_feat]
         # and are fully transposed before & after process
-        # FIXME: is unpack/transpose/repack for qweight and qzeros also needed?
-        # is there any combination of group quantization that requires unpacking?
         if bool(trans_required_pattern.match(fms_name)):
-            param_t_size = param.t().size()
-
             # TODO: less hardcoded way to determine head_size?
-            if param_t_size[1] == 2560:
+            if param.size(0) == 2560:
                 head_size = 80  # granite 3b code
             else:
                 head_size = 128  # every other Llama model in existence
+
+            param_t_size = param.t().size()
             nheads = int(param_t_size[0] / head_size)
 
-            fms_unfused_sd[fms_name] = (
-                param.t()
-                .view(nheads, 2, -1, param_t_size[1])
-                .transpose(1, 2)
-                .reshape(*param_t_size)
-                .t()
-            )
+            if param.dim() == 2:  # all qparams except bias
+                fms_unfused_sd[fms_name] = (
+                    param.t()
+                    .view(nheads, 2, -1, param_t_size[1])
+                    .transpose(1, 2)
+                    .reshape(*param_t_size)
+                    .t()
+                )
+            else:  # bias
+                fms_unfused_sd[fms_name] = (
+                    param.view(nheads, 2, -1).transpose(1, 2).reshape(*param.size())
+                )
     return fms_unfused_sd
 
 


### PR DESCRIPTION
- fix gptq adapter for llama models to properly transposes bias (needed for granite-8b)
- changed how a model is identified as "gptq", to include future "gptq_cpu" linear type
- gave more flexibility to gptq source, so that it can be passed as either "gptq_hf_unfused" (which selects the correct adapter) or "hf" (and automatically converted to "gptq_hf_unfused", for gptq models only)