### PR TITLE
Force dynamic shapes for kv cache in generate()

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -111,7 +111,6 @@ def _make_cache_contiguous(past_key_value_states):
                 .clone(memory_format=torch.contiguous_format)
                 .detach()
             )
-            torch._dynamo.mark_dynamic(n_kv_s[layer_idx][tensor_idx], 2)
     return n_kv_s
 
 


### PR DESCRIPTION
This PR forces the sequence dimension in the kv cache to be dynamic for torch.compile() if dynamic shapes are enabled for generate(). This reduces tracing time as one less trace needs to happen during generation. If the user forces static shapes when calling generate(), this is disabled.