### PR TITLE
NestedTensor Support in LLAMA Forward Pass

### DIFF
--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -994,7 +994,14 @@ class HFDecoderModelArchitecture(HFModelArchitecture):
         decoder_attention_mask = mask_2d_to_3d(hf_dec_attention_mask)
         # if user provides labels and decoder mask during training, we expect them to be compatible and do not check
         # we simply convert the decoder mask to a causal mask
-        decoder_attention_mask = decoder_attention_mask.tril(diagonal=0)
+        # decoder_attention_mask = decoder_attention_mask.tril(diagonal=0)
+
+        # hpml_ibm
+        if not decoder_attention_mask.is_nested:
+            decoder_attention_mask = decoder_attention_mask.tril(diagonal=0)
+        else:
+            decoder_attention_mask = torch.nested.nested_tensor([single_decoder_mask.tril(diagonal=0) for single_decoder_mask in decoder_attention_mask.unbind(0)])
+            
         if is_cache_used_and_filled:
             decoder_attention_mask = decoder_attention_mask[:, -1:, :]
         return decoder_attention_mask, hf_dec_attention_mask

--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -994,14 +994,10 @@ class HFDecoderModelArchitecture(HFModelArchitecture):
         decoder_attention_mask = mask_2d_to_3d(hf_dec_attention_mask)
         # if user provides labels and decoder mask during training, we expect them to be compatible and do not check
         # we simply convert the decoder mask to a causal mask
-        # decoder_attention_mask = decoder_attention_mask.tril(diagonal=0)
-
-        # hpml_ibm
         if not decoder_attention_mask.is_nested:
             decoder_attention_mask = decoder_attention_mask.tril(diagonal=0)
         else:
             decoder_attention_mask = torch.nested.nested_tensor([single_decoder_mask.tril(diagonal=0) for single_decoder_mask in decoder_attention_mask.unbind(0)])
-            
         if is_cache_used_and_filled:
             decoder_attention_mask = decoder_attention_mask[:, -1:, :]
         return decoder_attention_mask, hf_dec_attention_mask

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -48,8 +48,22 @@ def mask_2d_to_3d(inp: torch.Tensor) -> torch.Tensor:
     mask : torch.Tensor
         Mask tensor corresponding to inp. Will be of shape [batch_size, sequence_length, sequence_length].
     """
-    is_pad = inp == 0
-    mask = is_pad.unsqueeze(-1) == is_pad.unsqueeze(-2)
+    # is_pad = inp == 0
+    # mask = is_pad.unsqueeze(-1) == is_pad.unsqueeze(-2)
+
+    # hpml_ibm
+    if not inp.is_nested:
+        is_pad = inp == 0    
+        mask = is_pad.unsqueeze(-1) == is_pad.unsqueeze(-2)
+    else:    
+        sequence_masks = []
+        for sequence in inp.unbind(0):
+            is_pad = sequence == 0
+            single_mask = is_pad.unsqueeze(-1) == is_pad.unsqueeze(-2)
+            sequence_masks.append(single_mask)
+        
+        mask = torch.nested.nested_tensor(sequence_masks)
+
     return mask
 
 

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -48,14 +48,11 @@ def mask_2d_to_3d(inp: torch.Tensor) -> torch.Tensor:
     mask : torch.Tensor
         Mask tensor corresponding to inp. Will be of shape [batch_size, sequence_length, sequence_length].
     """
-    # is_pad = inp == 0
-    # mask = is_pad.unsqueeze(-1) == is_pad.unsqueeze(-2)
-
-    # hpml_ibm
+     
     if not inp.is_nested:
         is_pad = inp == 0    
         mask = is_pad.unsqueeze(-1) == is_pad.unsqueeze(-2)
-    else:    
+    else:
         sequence_masks = []
         for sequence in inp.unbind(0):
             is_pad = sequence == 0

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -148,17 +148,18 @@ class LLaMABlock(nn.Module):
             x, cache = x
         if self.config.p_dropout != 0:
             x = self.dropout(x)
-        # residual connection
-        # x = x + residual
-
-        # hpml_ibm
-        if not (x.is_nested ^ residual.is_nested):
-            if not x.is_nested:
-                x = x + residual
-            else:
-                x = torch.nested.as_nested_tensor([x_ + residual_ for (x_, residual_) in zip(x.unbind(0), residual.unbind(0))], layout=torch.jagged)
-        else:
-            raise ValueError("Either of the two, X or residual, is not nested... the other is")
+            
+        # Clone and copy to handle shape mismatch errors
+        # while adding nested tensors
+        if x.is_nested:
+            src_clone = x.clone()
+            num_samples = len(residual)
+            for idx in range(num_samples):
+                src_clone[idx].copy_(residual[idx])
+            residual = src_clone
+            
+        # residual connection        
+        x = x + residual
 
         # then we do FF and Add&Norm
         residual = x
@@ -167,16 +168,7 @@ class LLaMABlock(nn.Module):
         if self.config.p_dropout != 0:
             x = self.dropout(x)
         # another residual
-        # x = x + residual
-
-        # hpml_ibm
-        if not (x.is_nested ^ residual.is_nested):
-            if not x.is_nested:
-                x = x + residual
-            else:
-                x = torch.nested.as_nested_tensor([x_ + residual_ for (x_, residual_) in zip(x.unbind(0), residual.unbind(0))], layout=torch.jagged)
-        else:
-            raise ValueError("Either of the two, X or residual, is not nested... the other is")
+        x = x + residual
 
         if use_cache:
             return (x, cache)
@@ -367,17 +359,12 @@ class LLaMA(nn.Module):
         if past_key_value_states is None or len(past_key_value_states) == 0:
             past_key_value_states = [None for _ in range(len(self.layers))]
 
-        # qlen = x_in.size(1)
-        # klen = x_in.size(1)
-
-        # hpml_ibm
-        if not x_in.is_nested: 
+        if not x_in.is_nested:
             qlen = x_in.size(1)
-            klen = x_in.size(1)
+            klen = qlen
         else:
-            # need to check for qlen if only one token has been passed in the tensors
             qlen = max([ele.size(0) for ele in x_in.unbind(0)])
-            klen = qlen 
+            klen = qlen
 
         # if we are using the cache, the key length needs to be extended with the past keys length
         if use_cache and past_key_value_states[0] is not None:

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -149,7 +149,16 @@ class LLaMABlock(nn.Module):
         if self.config.p_dropout != 0:
             x = self.dropout(x)
         # residual connection
-        x = x + residual
+        # x = x + residual
+
+        # hpml_ibm
+        if not (x.is_nested ^ residual.is_nested):
+            if not x.is_nested:
+                x = x + residual
+            else:
+                x = torch.nested.as_nested_tensor([x_ + residual_ for (x_, residual_) in zip(x.unbind(0), residual.unbind(0))], layout=torch.jagged)
+        else:
+            raise ValueError("Either of the two, X or residual, is not nested... the other is")
 
         # then we do FF and Add&Norm
         residual = x
@@ -158,7 +167,16 @@ class LLaMABlock(nn.Module):
         if self.config.p_dropout != 0:
             x = self.dropout(x)
         # another residual
-        x = x + residual
+        # x = x + residual
+
+        # hpml_ibm
+        if not (x.is_nested ^ residual.is_nested):
+            if not x.is_nested:
+                x = x + residual
+            else:
+                x = torch.nested.as_nested_tensor([x_ + residual_ for (x_, residual_) in zip(x.unbind(0), residual.unbind(0))], layout=torch.jagged)
+        else:
+            raise ValueError("Either of the two, X or residual, is not nested... the other is")
 
         if use_cache:
             return (x, cache)
@@ -349,8 +367,17 @@ class LLaMA(nn.Module):
         if past_key_value_states is None or len(past_key_value_states) == 0:
             past_key_value_states = [None for _ in range(len(self.layers))]
 
-        qlen = x_in.size(1)
-        klen = x_in.size(1)
+        # qlen = x_in.size(1)
+        # klen = x_in.size(1)
+
+        # hpml_ibm
+        if not x_in.is_nested: 
+            qlen = x_in.size(1)
+            klen = x_in.size(1)
+        else:
+            # need to check for qlen if only one token has been passed in the tensors
+            qlen = max([ele.size(0) for ele in x_in.unbind(0)])
+            klen = qlen 
 
         # if we are using the cache, the key length needs to be extended with the past keys length
         if use_cache and past_key_value_states[0] is not None:

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -355,13 +355,10 @@ class MultiHeadAttention(nn.Module):
         """
         # q, k, v: batch_size x seq_len x emb_dim
         # mask: batch_size x seq_len x seq_len
-        # batch_size, q_len, _ = q.size()
-
-        # hpml_ibm
         if not q.is_nested:
             batch_size, q_len, _ = q.size()
         else:
-            batch_size, q_len = len(q.unbind(0)), [ele.size(0) for ele in q.unbind(0)]
+            batch_size, q_len = q.size(0), -1
 
         # if this is self attention, we always recompute
         # cross attention only gets computed when a cache does not exist
@@ -375,19 +372,9 @@ class MultiHeadAttention(nn.Module):
             q_out, k_out, v_out = self.in_proj(q, k, v)
 
             # note: transposes will be moved in a later PR to fix dis-contiguous tensor issues
-            # queries = q_out.view(batch_size, q_len, self.nheads, self.emb_kq_per_head)
-            # keys = k_out.view(batch_size, q_len, self.kvheads, self.emb_kq_per_head)
-            # values = v_out.view(batch_size, q_len, self.kvheads, self.emb_v_per_head)
-
-            # hpml_ibm
-            if not q.is_nested:
-                queries = q_out.view(batch_size, q_len, self.nheads, self.emb_kq_per_head)
-                keys = k_out.view(batch_size, q_len, self.kvheads, self.emb_kq_per_head)
-                values = v_out.view(batch_size, q_len, self.kvheads, self.emb_v_per_head)
-            else:
-                queries = torch.nested.nested_tensor([q_nst_out.view(q_nst_len, self.nheads, self.emb_kq_per_head) for (q_nst_out, q_nst_len) in zip(q_out, q_len)])
-                keys = torch.nested.nested_tensor([k_nst_out.view(q_nst_len, self.kvheads, self.emb_kq_per_head) for (k_nst_out, q_nst_len) in zip(k_out, q_len)])
-                values = torch.nested.nested_tensor([v_nst_out.view(q_nst_len, self.kvheads, self.emb_v_per_head) for (v_nst_out, q_nst_len) in zip(v_out, q_len)])
+            queries = q_out.view(batch_size, q_len, self.nheads, self.emb_kq_per_head)
+            keys = k_out.view(batch_size, q_len, self.kvheads, self.emb_kq_per_head)
+            values = v_out.view(batch_size, q_len, self.kvheads, self.emb_v_per_head)
 
             # You want to apply rotary embeddings pre-cache
             if self.position_encoder is not None:
@@ -416,17 +403,8 @@ class MultiHeadAttention(nn.Module):
         if mask is not None:
             # Our expected mask format is bs x q_len x k_len, so to make it broadcastable
             # we need to create the nheads dimension
-            # while len(mask.size()) != 4:  # expects bs (x nheads) x q_len x kv_len
-            #     mask = mask.unsqueeze(1)
-
-            # hpml_ibm
-            if not mask.is_nested:
-                while len(mask.size()) != 4:  # expects bs (x nheads) x q_len x kv_len
-                    mask = mask.unsqueeze(1)
-                
-            else:
-                while len(mask.unbind(0)[0].size()) + 1 != 4:  # expects bs (x nheads) x q_len x kv_len
-                    mask = torch.nested.nested_tensor([ele.unsqueeze(0) for ele in mask.unbind(0)])
+            while len(mask[0].size()) + 1 != 4:  # expects bs (x nheads) x q_len x kv_len
+                mask = mask.unsqueeze(1)
 
         if self.position_encoder is not None:
             attn_mask: Optional[Tensor] = self.position_encoder.adjusted_mask(
@@ -460,40 +438,15 @@ class MultiHeadAttention(nn.Module):
         if attn_mask is not None and attn_mask.dtype != torch.bool:
             attn_mask = attn_mask.to(dtype=queries.dtype)
 
-        # attn = F.scaled_dot_product_attention(
-        #     queries,
-        #     keys_e,
-        #     values_e,
-        #     attn_mask=attn_mask,
-        #     dropout_p=self.p_dropout if self.training else 0.0,
-        #     is_causal=is_causal_mask,
-        #     scale=self.scale_factor,
-        # )
-
-        # hpml_ibm
-        if not attn_mask.is_nested:
-            attn = F.scaled_dot_product_attention(
-                queries,
-                keys_e,
-                values_e,
-                attn_mask=None,
-                dropout_p=self.p_dropout if self.training else 0.0,
-                # is_causal=is_causal_mask,
-                is_causal=True,
-                scale=self.scale_factor,
-            )
-        else:
-            # TODO: apparently this function doesnt take attn_mask when the input is nested... so pytorch needs to fix this
-            attn = F.scaled_dot_product_attention(
-                queries,
-                keys_e,
-                values_e,
-                attn_mask=None,
-                dropout_p=self.p_dropout if self.training else 0.0,
-                # is_causal=is_causal_mask,
-                is_causal=True,
-                scale=self.scale_factor,
-            )
+        attn = F.scaled_dot_product_attention(
+            queries,
+            keys_e,
+            values_e,
+            attn_mask=attn_mask,
+            dropout_p=self.p_dropout if self.training else 0.0,
+            is_causal=is_causal_mask,
+            scale=self.scale_factor,
+        )
 
         if attn_algorithm:
             torch.backends.cuda.enable_flash_sdp(self.previous_flash)
@@ -504,23 +457,11 @@ class MultiHeadAttention(nn.Module):
         # attn: b x h x qlen x ds
         # attn after permute: b x qlen x h x ds
         # b x qlen x (d)
-        # attn = (
-        #     attn.transpose(2, 1)
-        #     .contiguous()
-        #     .view(batch_size, q_len, self.nheads * self.emb_v_per_head)
-        # )
-
-        # hpml_ibm
-        if not attn.is_nested:
-            attn = (
-                attn.transpose(2, 1)
-                .contiguous()
-                .view(batch_size, q_len, self.nheads * self.emb_v_per_head)
-            )
-        else:
-            attn = attn.transpose(2, 1).contiguous()
-            attn = torch.nested.as_nested_tensor([ele.view(q_len_, self.nheads * self.emb_v_per_head).contiguous() for (ele, q_len_) in zip(attn.unbind(0), q_len)], layout=torch.jagged)
-
+        attn = (
+            attn.transpose(2, 1)
+            .contiguous()
+            .view(batch_size, q_len, self.nheads * self.emb_v_per_head)
+        )
         out = self.dense(attn)
 
         # if use_cache=True, we return the hidden_state as well as the kv cache

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -288,31 +288,7 @@ class GatedLinearUnit(nn.Module):
         if self.fused:
             out_fused = self.wg1_fused(x)
             wg, w1 = torch.split(out_fused, [self.hidden_dim, self.hidden_dim], dim=2)
-
-            # hpml_ibm
-            if not (wg.is_nested ^ w1.is_nested):
-                if not wg.is_nested:
-                    pass
-                else:
-                    wg = torch.nested.nested_tensor([ele for ele in wg.unbind(0)], layout=torch.jagged)
-                    w1 = torch.nested.nested_tensor([ele for ele in w1.unbind(0)], layout=torch.jagged)
-            else:
-                raise ValueError("Either of the two, wg or w1, is not nested... the other is")
-            
-            # out = self.a(wg) * w1
-
-            # hpml_ibm
-            if not (wg.is_nested ^ w1.is_nested):
-                if not wg.is_nested:
-                    # out = self.a(wg) * w1
-                    temp = self.a(wg)
-                    out = temp * w1
-                else:
-                    temp = self.a(wg)
-                    out = torch.nested.nested_tensor([temp_ * w1_ for (temp_, w1_) in zip(temp.unbind(0), w1.unbind(0))])            
-            else:
-                raise ValueError("Either of the two, wg or w1, is not nested... the other is")
-
+            out = self.a(wg) * w1
         else:
             out = self.a(self.wg(x)) * self.w1(x)
         if self.p_dropout:

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -288,7 +288,31 @@ class GatedLinearUnit(nn.Module):
         if self.fused:
             out_fused = self.wg1_fused(x)
             wg, w1 = torch.split(out_fused, [self.hidden_dim, self.hidden_dim], dim=2)
-            out = self.a(wg) * w1
+
+            # hpml_ibm
+            if not (wg.is_nested ^ w1.is_nested):
+                if not wg.is_nested:
+                    pass
+                else:
+                    wg = torch.nested.nested_tensor([ele for ele in wg.unbind(0)], layout=torch.jagged)
+                    w1 = torch.nested.nested_tensor([ele for ele in w1.unbind(0)], layout=torch.jagged)
+            else:
+                raise ValueError("Either of the two, wg or w1, is not nested... the other is")
+            
+            # out = self.a(wg) * w1
+
+            # hpml_ibm
+            if not (wg.is_nested ^ w1.is_nested):
+                if not wg.is_nested:
+                    # out = self.a(wg) * w1
+                    temp = self.a(wg)
+                    out = temp * w1
+                else:
+                    temp = self.a(wg)
+                    out = torch.nested.nested_tensor([temp_ * w1_ for (temp_, w1_) in zip(temp.unbind(0), w1.unbind(0))])            
+            else:
+                raise ValueError("Either of the two, wg or w1, is not nested... the other is")
+
         else:
             out = self.a(self.wg(x)) * self.w1(x)
         if self.p_dropout:

--- a/fms/modules/layernorm.py
+++ b/fms/modules/layernorm.py
@@ -63,10 +63,46 @@ class LayerNormParameterized(nn.Module):
         xf = x
         if self.use_high_precision_pow:
             xf = x.float()
-        xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + self.eps)
-        x = xf.type_as(x)
-        if self.elementwise_scale:
-            x = self.weight * x
-        if self.elementwise_shift:
-            x = x + self.bias
+        # xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + self.eps)
+
+        # hpml_ibm
+        if not xf.is_nested: 
+            xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + self.eps)
+        else:
+            xf_list = []
+            for ele in xf.unbind(0):
+                temp = ele.pow(2).mean(-1, keepdim=True)
+                temp = temp + self.eps
+                temp = torch.rsqrt(temp)
+                temp = ele * temp 
+                xf_list.append(temp)
+
+            xf = torch.nested.nested_tensor(xf_list)
+            
+        # x = xf.type_as(x)
+
+        # hpml_ibm
+        if not xf.is_nested:
+            x = xf.type_as(x)
+        else:
+            first_vector = xf.unbind(0)[0]
+            x = torch.nested.nested_tensor([ele.type_as(first_vector) for ele in xf.unbind(0)])
+
+        # if self.elementwise_scale:
+        #     x = self.weight * x
+        # if self.elementwise_shift:
+        #     x = x + self.bias
+
+        # hpml_ibm
+        if not x.is_nested:
+            if self.elementwise_scale:
+                x = self.weight * x
+            if self.elementwise_shift:
+                x = x + self.bias
+        else:
+            if self.elementwise_scale:
+                x = torch.nested.nested_tensor([self.weight * ele for ele in x.unbind(0)])
+            if self.elementwise_shift:
+                x = torch.nested.nested_tensor([self.bias + ele for ele in x.unbind(0)])
+
         return x

--- a/fms/modules/layernorm.py
+++ b/fms/modules/layernorm.py
@@ -63,46 +63,10 @@ class LayerNormParameterized(nn.Module):
         xf = x
         if self.use_high_precision_pow:
             xf = x.float()
-        # xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + self.eps)
-
-        # hpml_ibm
-        if not xf.is_nested: 
-            xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + self.eps)
-        else:
-            xf_list = []
-            for ele in xf.unbind(0):
-                temp = ele.pow(2).mean(-1, keepdim=True)
-                temp = temp + self.eps
-                temp = torch.rsqrt(temp)
-                temp = ele * temp 
-                xf_list.append(temp)
-
-            xf = torch.nested.nested_tensor(xf_list)
-            
-        # x = xf.type_as(x)
-
-        # hpml_ibm
-        if not xf.is_nested:
-            x = xf.type_as(x)
-        else:
-            first_vector = xf.unbind(0)[0]
-            x = torch.nested.nested_tensor([ele.type_as(first_vector) for ele in xf.unbind(0)])
-
-        # if self.elementwise_scale:
-        #     x = self.weight * x
-        # if self.elementwise_shift:
-        #     x = x + self.bias
-
-        # hpml_ibm
-        if not x.is_nested:
-            if self.elementwise_scale:
-                x = self.weight * x
-            if self.elementwise_shift:
-                x = x + self.bias
-        else:
-            if self.elementwise_scale:
-                x = torch.nested.nested_tensor([self.weight * ele for ele in x.unbind(0)])
-            if self.elementwise_shift:
-                x = torch.nested.nested_tensor([self.bias + ele for ele in x.unbind(0)])
-
+        xf = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + self.eps)
+        x = xf.type_as(x)
+        if self.elementwise_scale:
+            x = self.weight * x
+        if self.elementwise_shift:
+            x = x + self.bias
         return x

--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -231,31 +231,22 @@ class RotaryEmbedding(PositionEncoder):
             not always be the pre-cached position 0...S. For kv-caching without dynamic batching
             or variable per-row left padding position_ids is shared for all the batch.
         """
-        # assert len(q.size()) == 4
-        # assert len(k.size()) == 4
 
-        # hpml_ibm
         if not q.is_nested:
             assert len(q.size()) == 4
             assert len(k.size()) == 4
         else:
-            assert len(q.unbind(0)[0].size()) + 1 == 4
-            assert len(k.unbind(0)[0].size()) + 1 == 4
-
-        # seq_len = max(k.size(1), q.size(1))
-
-        # hpml_ibm
-        if not (k.is_nested ^ q.is_nested):
-            if not k.is_nested:
-                seq_len = max(k.size(1), q.size(1))
-            else:
-                seq_len = max(
-                    max([ele.size(0) for ele in k.unbind(0)]),
-                    max([ele.size(0) for ele in q.unbind(0)])
-                )
+            assert len(q[0].size()) + 1 == 4
+            assert len(k[0].size()) + 1 == 4
+            
+        if not k.is_nested:
+            seq_len = max(k.size(1), q.size(1))
         else:
-            raise ValueError("Either of the two, K or Q, is not nested... the other is") 
-        
+            seq_len = max(
+                max([ele.size(0) for ele in k]),
+                max([ele.size(0) for ele in q])
+            )
+
         if position_ids is None:
             # Compute position_ids based on cache config
             position_ids = torch.arange(
@@ -264,68 +255,61 @@ class RotaryEmbedding(PositionEncoder):
             if use_cache and past_kv_state is not None and past_kv_state[0].numel() > 0:
                 position_ids += past_kv_state[0].size(2)
 
-        # q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
-        # k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2
-
-        # hpml_ibm
-        if not (k.is_nested ^ q.is_nested):
-            if not k.is_nested:
-                q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
-                k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2
-            else:
-                q_ = torch.nested.nested_tensor([ele.view(*ele.size()[:-1], -1, 2) for ele in q.float().unbind(0)])
-                k_ = torch.nested.nested_tensor([ele.view(*ele.size()[:-1], -1, 2) for ele in k.float().unbind(0)])
+        if not k.is_nested:
+            q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
+            k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2
         else:
-            raise ValueError("Either of the two, K or Q, is not nested... the other is")
-
+            q_ = q.float().view(q.size(0), -1, q.size(2), q.size(3)//2, 2)  # B L H D/2 2
+            k_ = k.float().view(k.size(0), -1, k.size(2), k.size(3)//2, 2)  # B L H D/2 2
+               
         # the max start position should be based on the max first position of each sequence
         max_start_pos = torch.max(position_ids[:, 0])
         alpha = self.compute_freqs_cis(q.device, max_start_pos + seq_len)
         freqs = self.cached_freqs[q.device.index][alpha][position_ids]
 
         freqs = freqs.float()  # 1 L D/2 2 2
-        # q_out = (
-        #     freqs[:, -q.size(1) :, None, :, :, :]
-        #     .mul(q_.unsqueeze(-2))
-        #     .sum(5)
-        #     .flatten(3)
-        # ).type_as(q)
-        # k_out = (
-        #     freqs[:, -k.size(1) :, None, :, :, :]
-        #     .mul(k_.unsqueeze(-2))
-        #     .sum(5)
-        #     .flatten(3)
-        # ).type_as(k)
 
-        # hpml_ibm
-        if not (k.is_nested ^ q.is_nested):
-            if not k.is_nested:
-                q_out = (
-                    freqs[:, -q.size(1) :, None, :, :, :]
-                    .mul(q_.unsqueeze(-2))
-                    .sum(5)
-                    .flatten(3)
-                ).type_as(q)
+        if not k.is_nested:
+            q_out = (
+                freqs[:, -q.size(1) :, None, :, :, :]
+                .mul(q_.unsqueeze(-2))
+                .sum(5)
+                .flatten(3)
+            ).type_as(q)
 
-                k_out = (
-                    freqs[:, -k.size(1) :, None, :, :, :]
-                    .mul(k_.unsqueeze(-2))
-                    .sum(5)
-                    .flatten(3)
-                ).type_as(k)
-            else:
-                q_out = torch.nested.nested_tensor([(freqs[i, : q_ele.size(0), None, :, :, :].mul(q_ele_.unsqueeze(-2)).sum(4).flatten(2)).type_as(q_ele) for i, (q_ele, q_ele_) in enumerate(zip(q.unbind(0), q_.unbind(0)))])
-                k_out = torch.nested.nested_tensor([(freqs[i, : k_ele.size(0), None, :, :, :].mul(k_ele_.unsqueeze(-2)).sum(4).flatten(2)).type_as(k_ele) for i, (k_ele, k_ele_) in enumerate(zip(k.unbind(0), k_.unbind(0)))])
+            k_out = (
+                freqs[:, -k.size(1) :, None, :, :, :]
+                .mul(k_.unsqueeze(-2))
+                .sum(5)
+                .flatten(3)
+            ).type_as(k)
+        
         else:
-            raise ValueError("Either of the two, K or Q, is not nested... the other is")
+            q_out = torch.nested.nested_tensor(
+                [
+                    (
+                        freqs[i, : q_ele.size(0), None, :, :, :]
+                        .mul(q_ele_.unsqueeze(-2))
+                        .sum(4)
+                        .flatten(2)
+                    ).type_as(q_ele) 
+                    for i, (q_ele, q_ele_) in enumerate(zip(q.unbind(0), q_.unbind(0)))
+                ], layout=torch.jagged
+            )
+            
+            k_out = torch.nested.nested_tensor(
+                [
+                    (
+                        freqs[i, : k_ele.size(0), None, :, :, :]
+                        .mul(k_ele_.unsqueeze(-2))
+                        .sum(4)
+                        .flatten(2)
+                    ).type_as(k_ele) 
+                    for i, (k_ele, k_ele_) in enumerate(zip(k.unbind(0), k_.unbind(0)))
+                ], layout=torch.jagged
+            )
 
-        # return q_out.view_as(q), k_out.view_as(k)
-        # hpml_ibm
-        if not (k.is_nested ^ q.is_nested):
-            if not k.is_nested:
-                return q_out.view_as(q), k_out.view_as(k)
-            else:
-                return torch.nested.nested_tensor([q_out_.view_as(q_) for q_, q_out_ in zip(q.unbind(0), q_out.unbind(0))]), torch.nested.nested_tensor([k_out_.view_as(k_) for k_, k_out_ in zip(k.unbind(0), k_out.unbind(0))])
+        if not k.is_nested:
+            return q_out.view_as(q), k_out.view_as(k)
         else:
-            raise ValueError("Either of the two, K or Q, is not nested... the other is")
-
+            return q_out.view(q.size(0), -1, q.size(2), q.size(3)), k_out.view(k.size(0), -1, k.size(2), k.size(3))

--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -231,10 +231,31 @@ class RotaryEmbedding(PositionEncoder):
             not always be the pre-cached position 0...S. For kv-caching without dynamic batching
             or variable per-row left padding position_ids is shared for all the batch.
         """
-        assert len(q.size()) == 4
-        assert len(k.size()) == 4
+        # assert len(q.size()) == 4
+        # assert len(k.size()) == 4
 
-        seq_len = max(k.size(1), q.size(1))
+        # hpml_ibm
+        if not q.is_nested:
+            assert len(q.size()) == 4
+            assert len(k.size()) == 4
+        else:
+            assert len(q.unbind(0)[0].size()) + 1 == 4
+            assert len(k.unbind(0)[0].size()) + 1 == 4
+
+        # seq_len = max(k.size(1), q.size(1))
+
+        # hpml_ibm
+        if not (k.is_nested ^ q.is_nested):
+            if not k.is_nested:
+                seq_len = max(k.size(1), q.size(1))
+            else:
+                seq_len = max(
+                    max([ele.size(0) for ele in k.unbind(0)]),
+                    max([ele.size(0) for ele in q.unbind(0)])
+                )
+        else:
+            raise ValueError("Either of the two, K or Q, is not nested... the other is") 
+        
         if position_ids is None:
             # Compute position_ids based on cache config
             position_ids = torch.arange(
@@ -243,8 +264,19 @@ class RotaryEmbedding(PositionEncoder):
             if use_cache and past_kv_state is not None and past_kv_state[0].numel() > 0:
                 position_ids += past_kv_state[0].size(2)
 
-        q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
-        k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2
+        # q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
+        # k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2
+
+        # hpml_ibm
+        if not (k.is_nested ^ q.is_nested):
+            if not k.is_nested:
+                q_ = q.float().view(*q.size()[:-1], -1, 2)  # B L H D/2 2
+                k_ = k.float().view(*k.size()[:-1], -1, 2)  # B L H D/2 2
+            else:
+                q_ = torch.nested.nested_tensor([ele.view(*ele.size()[:-1], -1, 2) for ele in q.float().unbind(0)])
+                k_ = torch.nested.nested_tensor([ele.view(*ele.size()[:-1], -1, 2) for ele in k.float().unbind(0)])
+        else:
+            raise ValueError("Either of the two, K or Q, is not nested... the other is")
 
         # the max start position should be based on the max first position of each sequence
         max_start_pos = torch.max(position_ids[:, 0])
@@ -252,17 +284,48 @@ class RotaryEmbedding(PositionEncoder):
         freqs = self.cached_freqs[q.device.index][alpha][position_ids]
 
         freqs = freqs.float()  # 1 L D/2 2 2
-        q_out = (
-            freqs[:, -q.size(1) :, None, :, :, :]
-            .mul(q_.unsqueeze(-2))
-            .sum(5)
-            .flatten(3)
-        ).type_as(q)
-        k_out = (
-            freqs[:, -k.size(1) :, None, :, :, :]
-            .mul(k_.unsqueeze(-2))
-            .sum(5)
-            .flatten(3)
-        ).type_as(k)
+        # q_out = (
+        #     freqs[:, -q.size(1) :, None, :, :, :]
+        #     .mul(q_.unsqueeze(-2))
+        #     .sum(5)
+        #     .flatten(3)
+        # ).type_as(q)
+        # k_out = (
+        #     freqs[:, -k.size(1) :, None, :, :, :]
+        #     .mul(k_.unsqueeze(-2))
+        #     .sum(5)
+        #     .flatten(3)
+        # ).type_as(k)
 
-        return q_out.view_as(q), k_out.view_as(k)
+        # hpml_ibm
+        if not (k.is_nested ^ q.is_nested):
+            if not k.is_nested:
+                q_out = (
+                    freqs[:, -q.size(1) :, None, :, :, :]
+                    .mul(q_.unsqueeze(-2))
+                    .sum(5)
+                    .flatten(3)
+                ).type_as(q)
+
+                k_out = (
+                    freqs[:, -k.size(1) :, None, :, :, :]
+                    .mul(k_.unsqueeze(-2))
+                    .sum(5)
+                    .flatten(3)
+                ).type_as(k)
+            else:
+                q_out = torch.nested.nested_tensor([(freqs[i, : q_ele.size(0), None, :, :, :].mul(q_ele_.unsqueeze(-2)).sum(4).flatten(2)).type_as(q_ele) for i, (q_ele, q_ele_) in enumerate(zip(q.unbind(0), q_.unbind(0)))])
+                k_out = torch.nested.nested_tensor([(freqs[i, : k_ele.size(0), None, :, :, :].mul(k_ele_.unsqueeze(-2)).sum(4).flatten(2)).type_as(k_ele) for i, (k_ele, k_ele_) in enumerate(zip(k.unbind(0), k_.unbind(0)))])
+        else:
+            raise ValueError("Either of the two, K or Q, is not nested... the other is")
+
+        # return q_out.view_as(q), k_out.view_as(k)
+        # hpml_ibm
+        if not (k.is_nested ^ q.is_nested):
+            if not k.is_nested:
+                return q_out.view_as(q), k_out.view_as(k)
+            else:
+                return torch.nested.nested_tensor([q_out_.view_as(q_) for q_, q_out_ in zip(q.unbind(0), q_out.unbind(0))]), torch.nested.nested_tensor([k_out_.view_as(k_) for k_, k_out_ in zip(k.unbind(0), k_out.unbind(0))])
+        else:
+            raise ValueError("Either of the two, K or Q, is not nested... the other is")
+


### PR DESCRIPTION
As part of Columbia University's HPML course project, we implemented support for nested tensors in the forward pass of the LLAMA model (micro version). This update enables LLAMA to accept nested tensors as input. Detailed experiments and findings are documented in the [nestedtensors-for-transformers](https://github.com/kushaangowda/nestedtensors-for-transformers) repository.