### PR TITLE
Modernize Tensor Parallelism using the DTensor API for Llama and Granite

### DIFF
--- a/fms/models/granite.py
+++ b/fms/models/granite.py
@@ -191,7 +191,7 @@ class GraniteHeadless(nn.Module):
         layers = []
         for i in range(self.config.nlayers):
             block: nn.Module = GraniteBlock(self.config, self.rot_emb)
-            block = self.distributed_strategy.distribute_layer(block, i)
+            block = self.distributed_strategy.distribute_layer(block, i, model='granite')
             layers.append(block)
         self.layers = nn.ModuleList(layers)
 
@@ -204,7 +204,7 @@ class GraniteHeadless(nn.Module):
             use_high_precision_pow=True,
         )
         self.dec_norm = self.distributed_strategy.distribute_module(
-            dec_norm, final_layers=True
+            dec_norm, final_layers=True, model='granite'
         )
 
         if self.config.p_dropout:

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -134,7 +134,7 @@ class LLaMABlock(nn.Module):
         residual = x
         x = self.ln(x)
         x = self.attn(
-            q=x,
+            x,
             mask=mask,
             position_ids=position_ids,
             attn_algorithm=attn_algorithm,
@@ -224,7 +224,7 @@ class LLaMA(nn.Module):
         layers = []
         for i in range(self.config.nlayers):
             block: nn.Module = LLaMABlock(self.config, self.rot_emb)
-            block = self.distributed_strategy.distribute_layer(block, i)
+            block = self.distributed_strategy.distribute_layer(block, i, model='llama')
             layers.append(block)
         self.layers = nn.ModuleList(layers)
 
@@ -237,7 +237,7 @@ class LLaMA(nn.Module):
             use_high_precision_pow=True,
         )
         self.dec_norm = self.distributed_strategy.distribute_module(
-            dec_norm, final_layers=True
+            dec_norm, final_layers=True, model='llama'
         )
 
         if self.config.p_dropout:
@@ -374,7 +374,7 @@ class LLaMA(nn.Module):
 
         for i, layer in enumerate(self.layers):
             output = layer(
-                x=x_in,
+                x_in,
                 mask=mask,
                 position_ids=position_ids,
                 past_key_value_state=past_key_value_states[i],

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -226,7 +226,10 @@ class FusedQKV(QKV):
             qkv = q
         else:
             raise ValueError("q, k, and v must be the same or k and v must be None")
-        return self.qkv_fused(qkv).split(self.splits, dim=-1)
+        
+        world_size = torch.distributed.get_world_size()
+        dim_split = [s//world_size for s in self.splits]
+        return self.qkv_fused(qkv).split(dim_split, dim=-1)
 
 
 class MultiHeadAttention(nn.Module):

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -287,7 +287,8 @@ class GatedLinearUnit(nn.Module):
     def forward(self, x):
         if self.fused:
             out_fused = self.wg1_fused(x)
-            wg, w1 = torch.split(out_fused, [self.hidden_dim, self.hidden_dim], dim=2)
+            world_size = torch.distributed.get_world_size()
+            wg, w1 = torch.split(out_fused, [self.hidden_dim//world_size, self.hidden_dim//world_size], dim=2)
             out = self.a(wg) * w1
         else:
             out = self.a(self.wg(x)) * self.w1(x)


### PR DESCRIPTION
PR modernizes IBM FMS TP code for Llama and Granite models by using the Tensor Parallel API (built on DTensors). 

Requires Torch 2.6 (https://download.pytorch.org/whl/nightly/cu124) to fix DTensor incompatibility with torch.compile (https://github.com/pytorch/pytorch/issues/108840).

Evaluated performance on the IBM benchmark script.

Other Details:
- Llama and Granite have comparable inference speed with the original IBM TP implementation, except for the uncompiled uncached benchmarks. This is because the non-distributed MultiHeadAttention layer is used and the Tensor Parallel API wraps the layers. Hence, there is no reduce_from_tensor_model_parallel_region call for the cache like in TPMultiHeadAttention.
- Llama and Granite use slightly more allocated memory for all benchmarks.
- Llama has significant reserved memory improvements for the uncompiled uncached end to end benchmark and all compiled benchmarks as sequence length increases. Granite on the other hand varies in terms of reserved memory performance. Granite performs better for sequence length 256, worse for sequence length 512, and similar for sequence length 1024 to the original IBM FMS implementation. The benchmarks were ran more than once to validate this behavior
