### PR TITLE
Update dependencies for FMS to a more modern stack

### DIFF
--- a/.github/workflows/fms-testing-app.yml
+++ b/.github/workflows/fms-testing-app.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       id: setup_python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Restore Virtualenv
       uses: actions/cache/restore@v4
       id: cache-venv-restore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,13 +6,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
         with:
-          options: "--check --diff --color"
           src: "."
-          version: "~= 23.3.0"
-      - uses: isort/isort-action@master
-        with:
-          sort-paths: fms
-
+          version: "~= 0.9.5"
+      - run: ruff check
+      - run: ruff format --check

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       id: setup_python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Restore Virtualenv
       uses: actions/cache/restore@v4
       id: cache-venv-restore

--- a/.github/workflows/scripts/ghstack-perm-check.py
+++ b/.github/workflows/scripts/ghstack-perm-check.py
@@ -116,7 +116,7 @@ class ChatOps:
 
         # Checking CI Jobs
         resp = self.gh.get(
-            f'https://api.github.com/repos/{self.REPO}/commits/{pr_obj["head"]["sha"]}/check-runs'
+            f"https://api.github.com/repos/{self.REPO}/commits/{pr_obj['head']['sha']}/check-runs"
         )
         self.must(resp.ok, "Error getting check runs status!")
         checkruns = resp.json()

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ fms.egg-info
 */**/*.pyc
 .vscode
 fms.egg-info
-
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ fms.egg-info
 .vscode
 fms.egg-info
 .venv
+.ruff_cache
+.mypy_cache

--- a/fms/datasets/__init__.py
+++ b/fms/datasets/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Mapping, Optional
+from typing import Callable, Mapping
 
 import torch
 from torch.utils.data import Dataset, IterableDataset
@@ -54,9 +54,17 @@ def get_dataset(name: str, tokenizer: BaseTokenizer, data: str = "", **kwargs):
 
 
 # avoid circular dependency
-from fms.datasets.util import (
+from fms.datasets.util import (  # noqa: E402
     PackedSequenceDataset,
     RestartableFromMapDataset,
     SavableDataset,
     WithSeparatorDataset,
 )
+
+__all__ = [
+    "get_dataset",
+    "PackedSequenceDataset",
+    "RestartableFromMapDataset",
+    "SavableDataset",
+    "WithSeparatorDataset",
+]

--- a/fms/datasets/arrow.py
+++ b/fms/datasets/arrow.py
@@ -7,7 +7,7 @@ import pyarrow as pa
 import torch
 import urllib3
 from pyarrow.fs import FileSystem, FileType, LocalFileSystem, S3FileSystem
-from torch.utils.data import Dataset, IterableDataset
+from torch.utils.data import IterableDataset
 
 from fms.datasets.util import SavableDataset
 

--- a/fms/distributed/strategy.py
+++ b/fms/distributed/strategy.py
@@ -1,6 +1,6 @@
 import os
 from abc import abstractmethod
-from typing import Any, List, Mapping
+from typing import List
 
 import torch
 import torch.distributed

--- a/fms/distributed/tensorparallel.py
+++ b/fms/distributed/tensorparallel.py
@@ -3,9 +3,6 @@
 import torch
 import torch._inductor.ir as ir
 import torch._inductor.lowering as lowering
-import torch.distributed as dist
-import torch.distributed._functional_collectives as funcol
-from torch import nn
 
 
 ## Fixes for PT 2.2 collectives until PT 2.3 is released

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -20,8 +20,7 @@ from fms.distributed.strategy import (
     UniformModelParallelStrategy,
 )
 from fms.modules import UninitializedModule
-from fms.modules.linear import UninitializedLinear, get_linear
-from fms.utils import fusion, serialization
+from fms.utils import serialization
 
 
 logger = logging.getLogger(__name__)
@@ -113,7 +112,8 @@ def __maybe_infer_model_variant(
         logger.info(f"inferring model configuration from {model_path_or_variant}")
 
         extra_kwargs = _infer_model_configuration(
-            model_path_or_variant, download_weights=is_hf_pretrained and variant is not None  # type: ignore[arg-type]
+            model_path_or_variant,
+            download_weights=is_hf_pretrained and variant is not None,  # type: ignore[arg-type]
         )
         architecture = extra_kwargs.pop("architecture")
         variant = extra_kwargs.pop("variant")
@@ -206,7 +206,7 @@ def _guess_num_layers(state_dict):
 
 
 def _class_hierarchy(clz):
-    if clz == object:
+    if clz is object:
         return {clz}
     bases = clz.__bases__
     all = [_class_hierarchy(c) for c in bases]
@@ -347,7 +347,7 @@ def get_model(
     if isinstance(data_type, str):  # convert str to torch.dtype
         try:
             data_type_parsed = getattr(torch, data_type)
-        except:
+        except AttributeError:
             raise ValueError(f"Data type `{data_type}` is not a supported torch dtype")
         if extra_args.get("linear_config", None) and "gptq" in extra_args[
             "linear_config"
@@ -485,4 +485,7 @@ def get_model(
     return fms_model
 
 
-from fms.models import gpt_bigcode, granite, llama, mixtral, roberta
+from fms.models import gpt_bigcode, granite, llama, mixtral, roberta  # noqa: E402
+
+
+__all__ = ["gpt_bigcode", "granite", "llama", "mixtral", "roberta"]

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -86,14 +86,6 @@ def __maybe_infer_model_variant(
         is_hf_configured = architecture == "hf_configured"
 
         if is_hf_pretrained:
-            if variant is None:
-                model_path_or_variant = model_path  # type: ignore[assignment]
-            else:
-                model_path_or_variant = variant
-        elif is_hf_configured:
-            model_path_or_variant = variant
-
-        if is_hf_pretrained:
             if ((variant is None) == (model_path is None)) or source is not None:
                 raise ValueError(
                     f"""
@@ -108,6 +100,15 @@ def __maybe_infer_model_variant(
             raise ValueError(
                 """architecture="hf_configured" implies model config is loaded from variant, therefore it should be set"""
             )
+
+        model_path_or_variant = ""
+        if is_hf_pretrained:
+            if variant is None:
+                model_path_or_variant = model_path  # type: ignore[assignment]
+            else:
+                model_path_or_variant = variant
+        elif is_hf_configured and variant is not None:
+            model_path_or_variant = variant
 
         logger.info(f"inferring model configuration from {model_path_or_variant}")
 

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -463,7 +463,11 @@ def get_model(
         if initial_device != torch.device("meta"):
             fms_model.to_empty(device=initial_device)
         # randomly initialize the model (non-gptq models only)
-        if hasattr(fms_model, "reset_parameters") and not is_gptq:
+        if (
+            hasattr(fms_model, "reset_parameters")
+            and callable(fms_model.reset_parameters)
+            and not is_gptq
+        ):
             fms_model.reset_parameters()
 
     if pre_load:
@@ -471,7 +475,7 @@ def get_model(
 
     # Call post-init to take care of post-wrapping/device-mapping initialization
     # Examples include tying weights, init Rope embeddings
-    if getattr(fms_model, "post_init", None):
+    if getattr(fms_model, "post_init", None) and callable(fms_model.post_init):
         fms_model.post_init()
 
     # Make sure any uninitialized tensors are at least moved to device

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -1,5 +1,4 @@
 import functools
-import math
 from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional, Tuple
 
@@ -31,9 +30,9 @@ class GPTBigCodeConfig(ModelConfig):
     emb_dropout: float = 0.0
     multiquery_attn: bool = True
     ln_eps: float = 1e-5
-    linear_config: Optional[
-        Mapping[str, Any]
-    ] = None  # pass as {"linear_type": str, <other kwargs>}
+    linear_config: Optional[Mapping[str, Any]] = (
+        None  # pass as {"linear_type": str, <other kwargs>}
+    )
     fused_weights: bool = True
 
 

--- a/fms/models/hf/__init__.py
+++ b/fms/models/hf/__init__.py
@@ -1,4 +1,6 @@
 # type: ignore
+from torch import nn
+from fms.models.hf.modeling_hf_adapter import HFModelArchitecture
 from fms.models.gpt_bigcode import GPTBigCode, GPTBigCodeHeadless
 from fms.models.hf.gpt_bigcode import HFAdaptedGPTBigCodeForCausalLM
 from fms.models.hf.gpt_bigcode.modeling_gpt_bigcode_hf import (
@@ -14,7 +16,7 @@ from fms.models.hf.roberta.modeling_roberta_hf import (
     HFAdaptedRoBERTaForMaskedLM,
     HFAdaptedRoBERTaHeadless,
 )
-from fms.models.hf.utils import as_fms_model, register_fms_models, to_hf_api
+from fms.models.hf.utils import register_fms_models
 from fms.models.llama import LLaMA
 from fms.models.mixtral import Mixtral, MixtralHeadless
 from fms.models.roberta import RoBERTa, RoBERTaHeadless
@@ -56,3 +58,32 @@ _causal_lm_models = [
 list of all masked-lm HF-Adapted models used in registration
 """
 _masked_lm_models = [HFAdaptedRoBERTaForMaskedLM]
+
+
+def to_hf_api(model: nn.Module, **override_config_kwargs) -> HFModelArchitecture:  # type: ignore
+    """Wrap an FMS model, converting its API to one of and Huggingface model
+
+    Parameters
+    ----------
+    model: nn.Module
+        The FMS model to wrap (currently one of LLaMA or GPTBigCode)
+    override_config_kwargs
+        configuration parameters to override as a set of keyword arguments
+
+    Returns
+    -------
+    HFModelArchitecture
+        an HF adapted FMS model
+    """
+    from fms.models.hf import _fms_to_hf_adapt_map  # type: ignore
+
+    register_fms_models()
+
+    model_type = type(model)
+    if model_type not in _fms_to_hf_adapt_map:
+        raise ValueError(
+            f"{model.__class__.__name__} is not one of {_fms_to_hf_adapt_map.keys()}"
+        )
+
+    hf_adapted_cls = _fms_to_hf_adapt_map[model_type]
+    return hf_adapted_cls.from_fms_model(model, **override_config_kwargs)

--- a/fms/models/hf/gpt_bigcode/__init__.py
+++ b/fms/models/hf/gpt_bigcode/__init__.py
@@ -1,8 +1,5 @@
-import os
-from typing import Union
-
 import torch
-from transformers import GPTBigCodeConfig, GPTBigCodeForCausalLM, PreTrainedModel
+from transformers import GPTBigCodeConfig, GPTBigCodeForCausalLM
 
 from fms.models.hf.gpt_bigcode.modeling_gpt_bigcode_hf import (
     HFAdaptedGPTBigCodeForCausalLM,

--- a/fms/models/hf/lm_head_mixins.py
+++ b/fms/models/hf/lm_head_mixins.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 
 import torch
 import torch.nn as nn

--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -1,7 +1,7 @@
 import abc
 import copy
 import os
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -10,8 +10,6 @@ from transformers import PretrainedConfig, PreTrainedModel
 from transformers.modeling_outputs import (
     BaseModelOutput,
     BaseModelOutputWithPastAndCrossAttentions,
-    CausalLMOutputWithCrossAttentions,
-    Seq2SeqLMOutput,
     Seq2SeqModelOutput,
 )
 from transformers.utils import ModelOutput, is_torch_fx_proxy
@@ -92,7 +90,7 @@ class _HFBase(PreTrainedModel):
     ):
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError(
-                f"You cannot specify both input_ids and inputs_embeds at the same time"
+                "You cannot specify both input_ids and inputs_embeds at the same time"
             )
 
         return_dict = (
@@ -1027,8 +1025,8 @@ class HFDecoderModelArchitecture(HFModelArchitecture):
             # we cannot compute the hf attention mask if no input ids are given
             else:
                 raise ValueError(
-                    f"if input_ids/inputs_embeds are not given, and attention_mask is not given, the attention_mask "
-                    f"cannot be computed"
+                    "if input_ids/inputs_embeds are not given, and attention_mask is not given, the attention_mask "
+                    "cannot be computed"
                 )
         # we are given some attention mask
         else:
@@ -1043,7 +1041,7 @@ class HFDecoderModelArchitecture(HFModelArchitecture):
                 hf_attention_mask = None
             else:
                 raise ValueError(
-                    f"attention mask needs to be given in either a 2d or 3d shape"
+                    "attention mask needs to be given in either a 2d or 3d shape"
                 )
         return attention_mask, hf_attention_mask
 

--- a/fms/models/hf/roberta/modeling_roberta_hf.py
+++ b/fms/models/hf/roberta/modeling_roberta_hf.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 import torch.nn as nn

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -107,35 +107,6 @@ def mask_2d_to_3d_bidirectional(
     return mask_encoder.unsqueeze(1) == mask_decoder.unsqueeze(2)
 
 
-def to_hf_api(model: nn.Module, **override_config_kwargs) -> "HFModelArchitecture":  # type: ignore
-    """Wrap an FMS model, converting its API to one of and Huggingface model
-
-    Parameters
-    ----------
-    model: nn.Module
-        The FMS model to wrap (currently one of LLaMA or GPTBigCode)
-    override_config_kwargs
-        configuration parameters to override as a set of keyword arguments
-
-    Returns
-    -------
-    HFModelArchitecture
-        an HF adapted FMS model
-    """
-    from fms.models.hf import _fms_to_hf_adapt_map  # type: ignore
-
-    register_fms_models()
-
-    model_type = type(model)
-    if model_type not in _fms_to_hf_adapt_map:
-        raise ValueError(
-            f"{model.__class__.__name__} is not one of {_fms_to_hf_adapt_map.keys()}"
-        )
-
-    hf_adapted_cls = _fms_to_hf_adapt_map[model_type]
-    return hf_adapted_cls.from_fms_model(model, **override_config_kwargs)
-
-
 def _infer_model_configuration(
     model_id_or_path: Union[str, os.PathLike],
     download_weights: bool = True,

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -108,7 +108,7 @@ def mask_2d_to_3d_bidirectional(
 
 
 def _infer_model_configuration(
-    model_id_or_path: Union[str, os.PathLike],
+    model_id_or_path: str | os.PathLike,
     download_weights: bool = True,
 ) -> Dict[str, Any]:
     # if the path does not exist, download it from huggingface and get the local path
@@ -134,13 +134,13 @@ def _infer_model_configuration(
             ignore_patterns = None
 
         model_path = snapshot_download(
-            repo_id=model_id_or_path,
+            repo_id=str(model_id_or_path),
             ignore_patterns=ignore_patterns,
             allow_patterns=allow_patterns,
             cache_dir=os.environ.get("HF_HOME", None),
         )
     else:
-        model_path = model_id_or_path
+        model_path = str(model_id_or_path)
 
     config = AutoConfig.from_pretrained(model_path)
 

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -20,7 +20,6 @@ from fms.modules.positions import RotaryEmbedding
 from fms.utils import serialization
 from fms.utils.activation import str_to_activation
 from fms.utils.config import ModelConfig
-from fms.utils.tokenizers import _has_hf
 
 
 logger = logging.getLogger(__name__)
@@ -721,89 +720,3 @@ serialization.register_adapter(
     "fms.pre0.0.6",
     ["pre0.0.6_attn_unfused_to_fused", "swiglu_unfused_to_fused", "weight_fusion"],
 )
-
-
-def convert_hf_llama(hf_model: "LlamaForCausalLM") -> LLaMA:  # type: ignore
-    """
-    Convert a Llama huggingface model to an fms model
-
-    Parameters
-    ----------
-    hf_model: LlamaForCausalLM
-        a Llama Huggingface model
-
-    Returns
-    -------
-    LLaMA
-        an FMS LLaMA model
-    """
-
-    if not _has_hf:
-        raise ImportError(
-            "in order to convert huggingface weights, you need to have transformers installed"
-        )
-
-    import re
-
-    config = LLaMAConfig(
-        src_vocab_size=hf_model.config.vocab_size,
-        emb_dim=hf_model.config.hidden_size,
-        norm_eps=hf_model.config.rms_norm_eps,
-        nheads=hf_model.config.num_attention_heads,
-        nlayers=hf_model.config.num_hidden_layers,
-        hidden_grow_factor=hf_model.config.intermediate_size
-        / hf_model.config.hidden_size,
-        multiple_of=1,  # this is set to 1 as it is encoded in the hidden dimension
-        activation_fn=hf_model.config.hidden_act,
-        max_expected_seq_len=hf_model.config.max_position_embeddings,
-        rope_theta=hf_model.config.rope_theta,
-    )
-    model = LLaMA(config)
-    count_parameters = lambda m: sum(p.numel() for p in m.parameters())
-    assert count_parameters(model) == count_parameters(hf_model)
-
-    hf_sd = hf_model.model.state_dict()
-
-    replacements = [
-        (r"^embed_tokens.weight", "shared.emb.weight"),
-        (r"^norm", "dec_norm"),
-        (r"^layers", "layers"),
-        (r"self_attn\.k_proj", "attn.key"),
-        (r"self_attn\.v_proj", "attn.value"),
-        (r"self_attn\.q_proj", "attn.query"),
-        (r"self_attn\.o_proj", "attn.dense"),
-        (r"mlp\.gate_proj", "ff_sub_layer.wg"),
-        (r"mlp\.up_proj", "ff_sub_layer.w1"),
-        (r"mlp\.down_proj", "ff_sub_layer.w2"),
-        (r"input_layernorm", "ln"),
-        (r"post_attention_layernorm", "ff_ln"),
-    ]
-    new_sd = {}
-    for name, param in hf_sd.items():
-        new_name = name
-        for pattern, repl in replacements:
-            new_name = re.sub(pattern, repl, new_name)
-        new_sd[new_name] = param
-
-    model.load_state_dict(new_sd, strict=False)
-    model.shared.head.weight = hf_model.lm_head.weight
-
-    # model.rot_emb.freqs = hf_model.model.layers[0].self_attn.rotary_emb.inv_freq
-    for layer in model.layers:
-        q = layer.attn.query.weight.data
-        q = (
-            q.view(model.config.nheads, 2, -1, q.size(1))
-            .transpose(1, 2)
-            .reshape(*q.size())
-        )
-        layer.attn.query.weight.data = q
-
-        k = layer.attn.key.weight.data
-        k = (
-            k.view(model.config.nheads, 2, -1, k.size(1))
-            .transpose(1, 2)
-            .reshape(*k.size())
-        )
-        layer.attn.key.weight.data = k
-
-    return model

--- a/fms/models/mixtral.py
+++ b/fms/models/mixtral.py
@@ -10,7 +10,6 @@ from fms import models
 from fms.distributed.strategy import (
     DistributedStrategy,
     NoOpStrategy,
-    UniformModelParallelStrategy,
 )
 from fms.modules.attention import MultiHeadAttention
 from fms.modules.feedforward import MOEFeedForward

--- a/fms/models/roberta.py
+++ b/fms/models/roberta.py
@@ -250,7 +250,9 @@ class RoBERTa(nn.Module):
 
         # this model ties weights, so we tie here
         if self.config.tie_heads:
-            self.classification_head.head.weight = self.base_model.embedding.weight
+            self.classification_head.get_submodule(
+                "head"
+            ).weight = self.base_model.embedding.weight
 
     def forward(
         self,

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Mapping, Optional, Set, Tuple
+from typing import Any, Mapping, Optional, Tuple
 
 import torch
 import torch.distributed
@@ -501,12 +501,14 @@ class TPMultiHeadAttention(MultiHeadAttention, TPModule):
         assert torch.distributed.is_initialized()
 
         rank, world_size = distributed.rank_and_world(group)
-        assert (
-            nheads % world_size == 0
-        ), "The number of heads must be divisible by world size"
+        assert nheads % world_size == 0, (
+            "The number of heads must be divisible by world size"
+        )
         assert (kvheads >= world_size and kvheads % world_size == 0) or (
             kvheads < world_size and world_size % kvheads == 0
-        ), "the kv heads must be divisible by the world size or the world size must be divisible by kv heads"
+        ), (
+            "the kv heads must be divisible by the world size or the world size must be divisible by kv heads"
+        )
         MultiHeadAttention.__init__(
             self,
             emb_dim,

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -548,7 +548,7 @@ class TPMultiHeadAttention(MultiHeadAttention, TPModule):
         if self.fused:
             module_sharding_info = {
                 "qkv_fused": LinearModuleShardingInfo(
-                    self.in_proj.qkv_fused,
+                    self.in_proj.get_submodule("qkv_fused"),
                     0,
                     [self.pre_tp_nheads, self.pre_tp_kvheads, self.pre_tp_kvheads],
                 ),
@@ -557,13 +557,13 @@ class TPMultiHeadAttention(MultiHeadAttention, TPModule):
         else:
             module_sharding_info = {
                 "query": LinearModuleShardingInfo(
-                    self.in_proj.query, 0, [self.pre_tp_nheads]
+                    self.in_proj.get_submodule("query"), 0, [self.pre_tp_nheads]
                 ),
                 "key": LinearModuleShardingInfo(
-                    self.in_proj.key, 0, [self.pre_tp_kvheads]
+                    self.in_proj.get_submodule("key"), 0, [self.pre_tp_kvheads]
                 ),
                 "value": LinearModuleShardingInfo(
-                    self.in_proj.value, 0, [self.pre_tp_kvheads]
+                    self.in_proj.get_submodule("value"), 0, [self.pre_tp_kvheads]
                 ),
                 "dense": LinearModuleShardingInfo(self.dense, 1, [self.world_size]),
             }

--- a/fms/modules/embedding.py
+++ b/fms/modules/embedding.py
@@ -1,10 +1,8 @@
-import math
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, Optional, Set
 
 import torch
 import torch.distributed
 import torch.nn as nn
-from numpy import sign
 from torch.distributed.distributed_c10d import ProcessGroup
 
 from fms import distributed
@@ -65,9 +63,9 @@ class WordEmbedding(nn.Module):
         self.tie_weights = tie_weights
         self.bias = bias
         self.max_pos = max_pos
-        assert (
-            reversible or not tie_weights
-        ), "Error: weights cannot be tied when there is no output head!"
+        assert reversible or not tie_weights, (
+            "Error: weights cannot be tied when there is no output head!"
+        )
         if padding_idx is None:
             self.emb = nn.Embedding(self.vocab_size, self.emb_dim)
         else:
@@ -105,12 +103,12 @@ class WordEmbedding(nn.Module):
         # vocab_idx: b n d if reverse, else b n
         if not reverse:
             if self.debug:
-                assert (
-                    inp.min().item() >= 0
-                ), f"Error: you have requested a negative vocab index: {inp.min().item()}"
-                assert (
-                    inp.max().item() < self.vocab_size
-                ), f"Error: you have requested an out of vocab index: {inp.max().item()}"
+                assert inp.min().item() >= 0, (
+                    f"Error: you have requested a negative vocab index: {inp.min().item()}"
+                )
+                assert inp.max().item() < self.vocab_size, (
+                    f"Error: you have requested an out of vocab index: {inp.max().item()}"
+                )
             out = self.emb(inp)
             if self.abs_pos:
                 pos = self.pos_id[:, : inp.size(1)]
@@ -123,9 +121,9 @@ class WordEmbedding(nn.Module):
             return out
         else:
             if self.debug:
-                assert (
-                    self.reversible
-                ), "Error: cannot make prediction when there is no output head!"
+                assert self.reversible, (
+                    "Error: cannot make prediction when there is no output head!"
+                )
             return self.head(inp)
 
 
@@ -160,12 +158,12 @@ class TPWordEmbedding(WordEmbedding, TPModule):
     ):
         assert torch.distributed.is_initialized()
         rank, world_size = distributed.rank_and_world(group)
-        assert (
-            emb_dim % world_size == 0
-        ), "The embedding dimensions must be divisible by world size"
-        assert (
-            vocab_size % world_size == 0
-        ), "The number of tokens must be divisible by world size"
+        assert emb_dim % world_size == 0, (
+            "The embedding dimensions must be divisible by world size"
+        )
+        assert vocab_size % world_size == 0, (
+            "The number of tokens must be divisible by world size"
+        )
         WordEmbedding.__init__(
             self,
             vocab_size,
@@ -190,9 +188,9 @@ class TPWordEmbedding(WordEmbedding, TPModule):
         if abs_pos:
             self.pos_emb = nn.Embedding(max_pos, self.emb_dim // world_size)
         if reversible:
-            assert (
-                self.vocab_size % world_size == 0
-            ), "The vocab size should be a multiple of the world size!"
+            assert self.vocab_size % world_size == 0, (
+                "The vocab size should be a multiple of the world size!"
+            )
             self.head = nn.Linear(
                 self.emb_dim, self.vocab_size // world_size, bias=bias
             )
@@ -289,9 +287,9 @@ class TPEmbedding(nn.Embedding, TPModule):
     ):
         assert torch.distributed.is_initialized()
         rank, world_size = distributed.rank_and_world(group)
-        assert (
-            embedding_dim % world_size == 0
-        ), "The embedding dimensions must be divisible by world size"
+        assert embedding_dim % world_size == 0, (
+            "The embedding dimensions must be divisible by world size"
+        )
         nn.Embedding.__init__(
             self, num_embeddings, embedding_dim // world_size, **kwargs
         )

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -129,9 +129,9 @@ class TPFeedForwardBlock(FeedForwardBlock, TPModule):
         if multiple_of:
             hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
         rank, world_size = distributed.rank_and_world(group)
-        assert (
-            hidden_dim % world_size == 0
-        ), "Hidden dim must be divisible by world size"
+        assert hidden_dim % world_size == 0, (
+            "Hidden dim must be divisible by world size"
+        )
         FeedForwardBlock.__init__(
             self,
             emb_dim,
@@ -359,9 +359,9 @@ class TPGatedLinearUnit(GatedLinearUnit, TPModule):
         hidden_dim = int(hidden_grow_factor * emb_dim)
         if multiple_of:
             hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
-        assert (
-            hidden_dim % world_size == 0
-        ), "Hidden dim must be divisible by world size"
+        assert hidden_dim % world_size == 0, (
+            "Hidden dim must be divisible by world size"
+        )
         GatedLinearUnit.__init__(
             self,
             emb_dim,
@@ -561,9 +561,9 @@ class TPConditionalFeedForward(ConditionalFeedForward, TPModule):
         assert torch.distributed.is_initialized()
         rank, world_size = distributed.rank_and_world(group)
 
-        assert (
-            intermediate_size % world_size == 0
-        ), "Intermediate size must be divisible by world size"
+        assert intermediate_size % world_size == 0, (
+            "Intermediate size must be divisible by world size"
+        )
         ConditionalFeedForward.__init__(
             self,
             num_experts,

--- a/fms/modules/feedforward.py
+++ b/fms/modules/feedforward.py
@@ -171,8 +171,8 @@ class TPFeedForwardBlock(FeedForwardBlock, TPModule):
         ffb: FeedForwardBlock, group: ProcessGroup
     ) -> "TPFeedForwardBlock":
         tp_ffb = TPFeedForwardBlock(
-            emb_dim=ffb.w1.in_features,
-            hidden_grow_factor=ffb.hidden_dim / ffb.w1.in_features,
+            emb_dim=getattr(ffb.w1, "in_features"),
+            hidden_grow_factor=ffb.hidden_dim / getattr(ffb.w1, "in_features"),
             multiple_of=None,
             activation_fn=ffb.a,
             p_dropout=ffb.p_dropout,

--- a/fms/modules/layernorm.py
+++ b/fms/modules/layernorm.py
@@ -1,8 +1,5 @@
-import math
-
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 
 class LayerNormParameterized(nn.Module):

--- a/fms/modules/linear.py
+++ b/fms/modules/linear.py
@@ -1,5 +1,3 @@
-import inspect
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, Callable, Mapping, Optional
 

--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -2,7 +2,6 @@ import math
 from typing import MutableMapping, Optional, Tuple
 
 import torch
-from torch import nn
 
 
 class PositionEncoder:

--- a/fms/modules/tp.py
+++ b/fms/modules/tp.py
@@ -1,7 +1,6 @@
-import itertools
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Dict, List, Set, Type, Union
+from typing import Dict, List, Set, Union
 
 import torch
 import torch.nn as nn

--- a/fms/testing/_internal/hf/model_test_suite.py
+++ b/fms/testing/_internal/hf/model_test_suite.py
@@ -9,24 +9,16 @@ from fms.models.hf.modeling_hf_adapter import (
     HFDecoderModelArchitecture,
     HFEncoderDecoderModelArchitecture,
 )
-from fms.models.hf.utils import register_fms_models, to_hf_api
+from fms.models.hf import to_hf_api
+from fms.models.hf.utils import register_fms_models
 from fms.testing._internal.model_test_suite import ConfigFixtureMixin
-
-
-SEED = 42
-torch.manual_seed(SEED)  # pytorch random seed
-np.random.seed(SEED)  # numpy random seed
-torch.backends.cudnn.deterministic = True
-
 
 import abc
 import itertools
 import tempfile
 from typing import List, Optional
 
-import numpy as np
 import pytest
-import torch
 import torch.nn as nn
 from transformers import (
     AutoConfig,
@@ -47,6 +39,12 @@ from ...comparison import (
     compare_model_signatures,
     get_signature,
 )
+
+
+SEED = 42
+torch.manual_seed(SEED)  # pytorch random seed
+np.random.seed(SEED)  # numpy random seed
+torch.backends.cudnn.deterministic = True
 
 
 SEED = 42
@@ -393,9 +391,9 @@ class HFModelGenerationTestSuite(HFConfigFixtureMixin, HFModelFixtureMixin):
             fms_hf_model, tokenizer, text2, use_cache, num_beams
         )[0]
 
-        assert (
-            output_batch[0] == output_text1
-        ), f"text 1 incorrect - \n{output_batch[0]}\n{output_text1}"
-        assert (
-            output_batch[1] == output_text2
-        ), f"text 2 incorrect - \n{output_batch[1]}\n{output_text2}"
+        assert output_batch[0] == output_text1, (
+            f"text 1 incorrect - \n{output_batch[0]}\n{output_text1}"
+        )
+        assert output_batch[1] == output_text2, (
+            f"text 2 incorrect - \n{output_batch[1]}\n{output_text2}"
+        )

--- a/fms/testing/_internal/model_test_suite.py
+++ b/fms/testing/_internal/model_test_suite.py
@@ -275,9 +275,10 @@ class ModelConsistencyTestSuite(ModelFixtureMixin, SignatureFixtureMixin):
         {_FAILED_MODEL_SIGNATURE_OUTPUT_MSG}
         """
 
-        torch.testing.assert_close(
-            torch.tensor(actual), torch.tensor(signature)
-        ), assertion_msg
+        (
+            torch.testing.assert_close(torch.tensor(actual), torch.tensor(signature)),
+            assertion_msg,
+        )
 
     def test_model_weight_keys(self, model, capture_expectation):
         import inspect
@@ -304,7 +305,7 @@ class ModelConsistencyTestSuite(ModelFixtureMixin, SignatureFixtureMixin):
             weight_keys_file = open(weight_keys_path)
             expected_keys = [k for k in weight_keys_file.readline().split(",")]
             assert actual_keys == expected_keys, _FAILED_MODEL_WEIGHTS_KEYS_MSG
-        except:
+        except OSError:
             pytest.fail(
                 "Weights Key file failed to load, please re-run the tests with --capture_expectation"
             )
@@ -325,6 +326,9 @@ class ModelConsistencyTestSuite(ModelFixtureMixin, SignatureFixtureMixin):
         Output for signature of unfused model is incorrect
         """
 
-        torch.testing.assert_close(
-            torch.tensor(unfused_signature), torch.tensor(signature)
-        ), assertion_msg
+        (
+            torch.testing.assert_close(
+                torch.tensor(unfused_signature), torch.tensor(signature)
+            ),
+            assertion_msg,
+        )

--- a/fms/training/plugins.py
+++ b/fms/training/plugins.py
@@ -303,7 +303,7 @@ class Checkpointer(TrainerPlugin):
             optim_dict = self.optimizer.state_dict()
 
         if step is not None:
-            file = f"{model_name}_{epoch:03d}_{step+1:05d}"
+            file = f"{model_name}_{epoch:03d}_{step + 1:05d}"
         else:
             file = f"{model_name}_{epoch:03d}_final"
         save_dir = self.save_dir

--- a/fms/triton/moe_kernel.py
+++ b/fms/triton/moe_kernel.py
@@ -139,7 +139,7 @@ def invoke_fused_moe_kernel(
     EM = padded_token_ids_per_block.shape[0]
     N = B.shape[1]
 
-    grid = lambda META: (
+    grid = lambda META: (  # noqa: E731
         triton.cdiv(EM, META["block_m"]) * triton.cdiv(N, META["block_n"]),
     )
 
@@ -180,7 +180,7 @@ def _autotune(configs, function):
                 stmt="f(*args, **kwargs)",
                 globals={"args": args, "kwargs": kwargs, "f": f},
             )
-        except:
+        except:  # noqa: E722
             return None
         return t0.blocked_autorange().mean * 1e6
 

--- a/fms/utils/__init__.py
+++ b/fms/utils/__init__.py
@@ -3,8 +3,6 @@ from typing import Optional
 
 from torch.distributed import ProcessGroup
 
-from fms.utils import gptq
-
 
 def print0(*args, group: Optional[ProcessGroup] = None):
     """

--- a/fms/utils/evaluation.py
+++ b/fms/utils/evaluation.py
@@ -25,9 +25,12 @@ class FMSEvalHarnessLM(LM):
         self._rank = rank
         self._world_size = world_size
         self.device = device
+
         # workaround for https://github.com/EleutherAI/lm-evaluation-harness/issues/1333
         # until the fix is in a release
-        generic_object = lambda: None
+        def generic_object():
+            return None
+
         self.model = generic_object
         self.model.config = generic_object  # type: ignore
         self.model.config._name_or_path = "FMSEvalHarnessLM"  # type: ignore

--- a/fms/utils/fusion.py
+++ b/fms/utils/fusion.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 def _maybe_unfuse_weights(module: nn.Module):
-    if hasattr(module, "unfuse_weights"):
+    if hasattr(module, "unfuse_weights") and callable(module.unfuse_weights):
         result = module.unfuse_weights()
         del module
     else:

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -103,7 +103,9 @@ def __update_padding_kwargs(
     return model_specific_kwargs
 
 
-def _make_cache_contiguous(past_key_value_states):
+def _make_cache_contiguous(
+    past_key_value_states: List[List[torch.Tensor]],
+) -> List[List[torch.Tensor]]:
     # kv updates are required for torch.compile with
     # mode='reduce-overhead'
     n_kv_s: List[List[torch.Tensor]] = []
@@ -118,7 +120,9 @@ def _make_cache_contiguous(past_key_value_states):
     return n_kv_s
 
 
-def _make_cache_dynamic(past_key_value_states):
+def _make_cache_dynamic(
+    past_key_value_states: List[List[torch.Tensor]],
+) -> List[List[torch.Tensor]]:
     # kv updates are required for torch.compile with
     # mode='reduce-overhead'
     for layer in past_key_value_states:

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -236,7 +236,7 @@ def generate(
         else:
             logits = output
 
-        if not "only_last_token" in kwargs:
+        if "only_last_token" not in kwargs:
             logits = logits[:, -1, :]
 
         if do_sample:

--- a/fms/utils/gptq.py
+++ b/fms/utils/gptq.py
@@ -167,7 +167,7 @@ def shard_gptq_linear(
     # If desc_act=False, correct the g_idx
     for module_name, module_info in module_sharding_info.items():
         if not module_info.linear_module.desc_act:
-            g_idx_param = module_info.linear_module.g_idx
+            g_idx_param: torch.Tensor = getattr(module_info.linear_module, "g_idx")
             module_info.linear_module.g_idx = g_idx_param - g_idx_param.min()
 
     return unused_keys

--- a/fms/utils/gptq.py
+++ b/fms/utils/gptq.py
@@ -178,8 +178,8 @@ def shard_gptq_linear(
     # If desc_act=False, correct the g_idx
     for module_name, module_info in module_sharding_info.items():
         if not module_info.linear_module.desc_act:
-            g_idx_param = module_info.linear_module.g_idx
-            module_info.linear_module.g_idx = g_idx_param - g_idx_param.min()
+            g_idx_param = getattr(module_info.linear_module, "g_idx")
+            setattr(module_info.linear_module, "g_idx", g_idx_param - g_idx_param.min())
 
     return unused_keys
 

--- a/fms/utils/gptq.py
+++ b/fms/utils/gptq.py
@@ -22,7 +22,7 @@ try:
     )
 
     IS_AUTOGPTQ_AVAILABLE = True
-except:
+except ImportError:
     IS_AUTOGPTQ_AVAILABLE = False
 
 
@@ -166,7 +166,7 @@ def shard_gptq_linear(
 
     # If desc_act=False, correct the g_idx
     for module_name, module_info in module_sharding_info.items():
-        if module_info.linear_module.desc_act == False:
+        if not module_info.linear_module.desc_act:
             g_idx_param = module_info.linear_module.g_idx
             module_info.linear_module.g_idx = g_idx_param - g_idx_param.min()
 

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -263,16 +263,13 @@ def get_adapted(
 
 # `models` imports each model class, causing models and adapters to be registered.
 # down here to avoid circular dependencies.
-from fms import models
 
 
 def _get_safetensors_item(key, file: Path, device: torch.device) -> torch.Tensor:
     from safetensors import safe_open  # type: ignore[import-untyped]
 
     with torch.no_grad():
-        with safe_open(
-            file, framework="pt", device=str(device)
-        ) as model_weights:  # type: ignore[attr-defined]
+        with safe_open(file, framework="pt", device=str(device)) as model_weights:  # type: ignore[attr-defined]
             return model_weights.get_tensor(key)
 
 
@@ -323,7 +320,7 @@ def load_state_dict(
     if model_path is None or initial_device.type == "meta":
         return {}
     if checkpoint_sharding == "fsdp" and distributed_strategy not in ["fsdp", "hsdp"]:
-        raise ValueError(f"FSDP checkpoints can only be loaded into an FSDP model")
+        raise ValueError("FSDP checkpoints can only be loaded into an FSDP model")
     if checkpoint_sharding == "tp" and distributed_strategy != "tp":
         raise ValueError("TP checkpoints can only be loaded into a TP model")
 
@@ -358,14 +355,14 @@ def load_state_dict(
         checkpoints = [model_path]
 
     # Check if we found some files
-    assert (
-        len(checkpoints) > 0
-    ), f"Can't find the requested checkpoint data at {model_path}"
+    assert len(checkpoints) > 0, (
+        f"Can't find the requested checkpoint data at {model_path}"
+    )
 
     if checkpoint_sharding is not None and checkpoint_sharding != "layer":
-        assert world_size == len(
-            checkpoints
-        ), f"Loading a {checkpoint_sharding}-sharded checkpoint with len={len(checkpoints)} but world size is {world_size}"
+        assert world_size == len(checkpoints), (
+            f"Loading a {checkpoint_sharding}-sharded checkpoint with len={len(checkpoints)} but world size is {world_size}"
+        )
 
         checkpoints = [checkpoints[rank]]
 
@@ -632,7 +629,7 @@ def _load_partial_state_dict(
                     )
                 )
                 unused_keys_tp = tp_module.load_weights(tensor_values)
-        except:
+        except:  # noqa: E722
             if unused_keys_tp:
                 unused_keys.update(unused_keys_tp)
             else:

--- a/fms/utils/tensors.py
+++ b/fms/utils/tensors.py
@@ -111,7 +111,7 @@ class ExpandableTensor(torch.Tensor):
     def cat(tensors, dim=0, *, out=None):
         if (
             len(tensors)
-            and type(tensors[0]) == ExpandableTensor
+            and type(tensors[0]) is ExpandableTensor
             and tensors[0]._dim == dim
         ):
             result = tensors[0]
@@ -120,7 +120,7 @@ class ExpandableTensor(torch.Tensor):
             return result
         else:
             tensors = [
-                tensor._tensor() if type(tensor) == ExpandableTensor else tensor
+                tensor._tensor() if type(tensor) is ExpandableTensor else tensor
                 for tensor in tensors
             ]
             return torch.cat(tensors, dim, out=out)
@@ -132,6 +132,6 @@ class ExpandableTensor(torch.Tensor):
         if func not in _HANDLED_FUNCTIONS or not all(
             issubclass(t, (torch.Tensor, ExpandableTensor)) for t in types
         ):
-            args = [a._tensor() if type(a) == ExpandableTensor else a for a in args]
+            args = [a._tensor() if type(a) is ExpandableTensor else a for a in args]
             return func(*args, **kwargs)
         return _HANDLED_FUNCTIONS[func](*args, **kwargs)

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -2,7 +2,6 @@ import os
 from typing import List, Optional, Union
 
 import torch
-import torch.nn.functional as F
 
 from fms import utils
 
@@ -74,7 +73,7 @@ class CharTokenizer(BaseTokenizer):
             # returning a single integer to be compatible with other tokenizers
             if len(tokens) != 1:
                 raise RuntimeError(
-                    f"Only single character str tokens can be converted using the CharTokenizer."
+                    "Only single character str tokens can be converted using the CharTokenizer."
                 )
             token_id = ord(tokens)
             return token_id if token_id < 256 else 0

--- a/fms/utils/tp_wrapping.py
+++ b/fms/utils/tp_wrapping.py
@@ -8,7 +8,7 @@ from fms.modules.positions import Alibi
 # this probably belongs somewhere else but can't go in fms.distribtued b/c
 # circular dependency.
 def _tp_wrapped(module: nn.Module, group: ProcessGroup):
-    if hasattr(module, "to_tp"):
+    if hasattr(module, "to_tp") and callable(module.to_tp):
         return module.to_tp(group)
     elif isinstance(module, Alibi):
         raise NotImplementedError("TODO: implement TP for Alibi")

--- a/hf-requirements.txt
+++ b/hf-requirements.txt
@@ -4,5 +4,5 @@
 
 -r requirements.txt
 
-numpy<2.0,>=1.17 # Needed by transformers
-transformers==4.47.1
+numpy # Needed by transformers
+transformers==4.48.3

--- a/notebooks/hf_adapted_inference.ipynb
+++ b/notebooks/hf_adapted_inference.ipynb
@@ -25,9 +25,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import transformers\n",
     "import torch\n",
-    "from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM\n",
+    "from transformers import pipeline, AutoTokenizer\n",
     "from fms.models import get_model\n",
     "from fms.models.hf import to_hf_api"
    ]
@@ -88,7 +87,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = get_model(architecture, variant, model_path=model_path, source=\"hf\", device_type=\"cuda\", norm_eps=1e-6)\n",
+    "model = get_model(\n",
+    "    architecture,\n",
+    "    variant,\n",
+    "    model_path=model_path,\n",
+    "    source=\"hf\",\n",
+    "    device_type=\"cuda\",\n",
+    "    norm_eps=1e-6,\n",
+    ")\n",
     "model = to_hf_api(model)"
    ]
   },
@@ -127,7 +133,13 @@
    ],
    "source": [
     "%%timeit -r 1 -n 1\n",
-    "pipe = pipeline(task=\"text-generation\", model=model, max_new_tokens=25, tokenizer=tokenizer, device=\"cuda\")\n",
+    "pipe = pipeline(\n",
+    "    task=\"text-generation\",\n",
+    "    model=model,\n",
+    "    max_new_tokens=25,\n",
+    "    tokenizer=tokenizer,\n",
+    "    device=\"cuda\",\n",
+    ")\n",
     "prompt = \"\"\"I believe the meaning of life is\"\"\"\n",
     "result = pipe(prompt)\n",
     "print(result)"
@@ -178,7 +190,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe = pipeline(task=\"text-generation\", model=model, max_new_tokens=25, tokenizer=tokenizer, device=\"cuda\")\n",
+    "pipe = pipeline(\n",
+    "    task=\"text-generation\",\n",
+    "    model=model,\n",
+    "    max_new_tokens=25,\n",
+    "    tokenizer=tokenizer,\n",
+    "    device=\"cuda\",\n",
+    ")\n",
     "prompt = \"\"\"I believe the meaning of life is\"\"\"\n",
     "result = pipe(prompt)"
    ]
@@ -208,7 +226,13 @@
    ],
    "source": [
     "%%timeit -r 1 -n 1\n",
-    "pipe = pipeline(task=\"text-generation\", model=model, max_new_tokens=25, tokenizer=tokenizer, device=\"cuda\")\n",
+    "pipe = pipeline(\n",
+    "    task=\"text-generation\",\n",
+    "    model=model,\n",
+    "    max_new_tokens=25,\n",
+    "    tokenizer=tokenizer,\n",
+    "    device=\"cuda\",\n",
+    ")\n",
     "prompt = \"\"\"I believe the meaning of life is\"\"\"\n",
     "result = pipe(prompt)\n",
     "print(result)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Used to install pinned dependencies
 # Useful for dev/test jobs caches
 # Must be kept in sync with setup.py
-torch == 2.2.0 # This is what is installed in CI today
+torch >= 2.5.1 # This is what is installed in CI today

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -252,9 +252,9 @@ def end_to_end(model, use_cache, expected=None):
         ),  # this is needed for reduce-overhead to work correctly for now
     )
     if local_rank == 0:
-        assert (
-            result.size()[-1] == SEQ_LEN + MAX_NEW_TOKENS
-        ), f"{result.size()}, {SEQ_LEN}, {MAX_NEW_TOKENS}"
+        assert result.size()[-1] == SEQ_LEN + MAX_NEW_TOKENS, (
+            f"{result.size()}, {SEQ_LEN}, {MAX_NEW_TOKENS}"
+        )
     if expected is not None and not args.skip_correctness_check:
         torch.testing.assert_close(result, expected)
     else:

--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -1,6 +1,5 @@
 import argparse
 import cmd
-import itertools
 import os
 import random
 import re
@@ -11,7 +10,7 @@ import torch._inductor.config
 from torch import distributed as dist
 
 from fms.models import get_model
-from fms.utils import generation, tokenizers
+from fms.utils import tokenizers
 from fms.utils.generation import generate
 
 

--- a/scripts/hf_compile_example.py
+++ b/scripts/hf_compile_example.py
@@ -5,7 +5,6 @@ import time
 import torch
 import transformers
 from torch import nn
-from transformers import pipeline
 
 from fms.models import llama
 from fms.models.hf.llama import modeling_llama_hf
@@ -67,7 +66,7 @@ def timed_generation(model: nn.Module, run: str):
     print(f"{run} took {end - start:,.2f} seconds")
     actual_new = result.shape[0] - input_ids.shape[1]
     print(f"\t- Generated {actual_new} new tokens")
-    print(f"\t- {(end-start) * 1000 / actual_new :,.2f} ms per generated token")
+    print(f"\t- {(end - start) * 1000 / actual_new:,.2f} ms per generated token")
     print(f'\t- Generated text: "{tokenizer.decode(result[-actual_new:])}"')
 
 

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -9,7 +9,7 @@ import torch._inductor.config
 from torch import distributed as dist
 
 from fms.models import get_model
-from fms.utils import fusion, generation, tokenizers
+from fms.utils import generation, tokenizers
 from fms.utils.generation import generate, pad_input_ids
 
 

--- a/scripts/train_causal.py
+++ b/scripts/train_causal.py
@@ -1,12 +1,10 @@
 import argparse
 import os
 from contextlib import nullcontext
-from datetime import timedelta
 from pathlib import Path
 
 import torch
 from torch import distributed as dist
-from torch import nn
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import ShardingStrategy
 from torch.utils.data import DataLoader
@@ -218,7 +216,7 @@ def peft_model(model):
     requires some care. The state_dict will also contain all paramters, not
     just the adapter, though we plan to use merged tuned models for now.
     """
-    from peft import LoraConfig, get_peft_config, get_peft_model
+    from peft import LoraConfig
     from peft.mapping import PeftModelForCausalLM
 
     from fms.models.hf.utils import to_hf_api

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     description="IBM Foundation Model Stack",
     url="https://github.com/foundation-model-stack/foundation-model-stack",
     packages=find_packages(),
-    install_requires=["torch >= 2.2"],
-    extras_require={"hf": ["transformers >= 4.40.2"]},
+    install_requires=["torch >= 2.5.1"],
+    extras_require={"hf": ["transformers >= 4.48.3"]},
     license="Apache License 2.0",
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,15 +4,15 @@
 -r hf-requirements.txt
 
 # Test tools
-mypy==1.8.0
+mypy==1.15.0
 mypy-extensions==1.0.0
-pytest==8.0.0
+pytest==8.3.4
 sentencepiece==0.2.0
 
 # Types packages
-pyarrow-stubs==10.0.1.7
-types-requests==2.31.0.20240125
+pyarrow-stubs==17.16
+types-requests==2.32.0.20241016
 
 # Model testing
-lm_eval==0.4.2
-peft==0.13.2
+lm_eval==0.4.7
+peft==0.14.0

--- a/tests/data/test_arrow.py
+++ b/tests/data/test_arrow.py
@@ -3,7 +3,6 @@ import random
 import tempfile
 
 import pyarrow as pa
-import pytest
 import torch
 
 from fms.datasets.arrow import ArrowFilesDataset

--- a/tests/distributed/test_tp.py
+++ b/tests/distributed/test_tp.py
@@ -3,7 +3,7 @@ import torch
 import torch.distributed
 import torch.nn
 
-from fms.modules.attention import MultiHeadAttention, TPMultiHeadAttention
+from fms.modules.attention import MultiHeadAttention
 from fms.modules.feedforward import FeedForwardBlock
 
 

--- a/tests/distributed/test_tp_gptq.py
+++ b/tests/distributed/test_tp_gptq.py
@@ -3,6 +3,7 @@ import torch
 import torch.distributed
 import torch.nn
 
+import fms.utils.gptq  # noqa: F401
 from fms.modules.attention import MultiHeadAttention
 from fms.modules.feedforward import FeedForwardBlock, GatedLinearUnit
 from fms.utils.config import ModelConfig

--- a/tests/models/hf/test_as_fms_model.py
+++ b/tests/models/hf/test_as_fms_model.py
@@ -11,7 +11,8 @@ from transformers import (
     pipeline,
 )
 
-from fms.models.hf import as_fms_model, to_hf_api
+from fms.models.hf import to_hf_api
+from fms.models.hf.utils import as_fms_model
 from fms.testing.comparison import HFModelSignatureParams, compare_model_signatures
 
 

--- a/tests/models/hf/test_gpt_bigcode_hf.py
+++ b/tests/models/hf/test_gpt_bigcode_hf.py
@@ -1,8 +1,5 @@
 import pytest
-import torch
 from transformers import (
-    GPTBigCodeConfig,
-    GPTBigCodeForCausalLM,
     PretrainedConfig,
     PreTrainedModel,
     PreTrainedTokenizer,

--- a/tests/models/hf/test_llama_hf.py
+++ b/tests/models/hf/test_llama_hf.py
@@ -82,6 +82,7 @@ class LLaMA2HFFixtures(ModelFixtureMixin, HFConfigFixtureMixin, HFModelFixtureMi
 
         with torch.no_grad():
             oss_hf_model.model.embed_tokens.weight.copy_(fms_hf_model.embedding.weight)
+            oss_hf_model.model.rotary_emb.inv_freqs = freqs
             i = 0
             for oss_hf_layer in oss_hf_model.model.layers:
                 fms_hf_layer = fms_hf_model.decoder.model.layers[i]
@@ -98,7 +99,6 @@ class LLaMA2HFFixtures(ModelFixtureMixin, HFConfigFixtureMixin, HFModelFixtureMi
                 oss_hf_layer.self_attn.o_proj.weight.copy_(
                     fms_hf_layer.attn.dense.weight
                 )
-                oss_hf_layer.self_attn.rotary_emb.inv_freqs = freqs
 
                 # mlp
                 wg1_fused = fms_hf_layer.ff_sub_layer.wg1_fused.weight

--- a/tests/models/hf_equivalence/test_gpt_bigcode.py
+++ b/tests/models/hf_equivalence/test_gpt_bigcode.py
@@ -3,14 +3,9 @@ import tempfile
 import pytest
 
 from fms.models import get_model
-from fms.models.gpt_bigcode import GPTBigCode
 from fms.models.hf import to_hf_api
-from fms.models.hf.gpt_bigcode.modeling_gpt_bigcode_hf import (
-    HFAdaptedGPTBigCodeForCausalLM,
-)
 from fms.testing.comparison import (
     HFModelSignatureParams,
-    ModelSignatureParams,
     compare_model_signatures,
 )
 
@@ -43,7 +38,10 @@ def test_gptbigcode_equivalence():
         eos_token_id=hf_model.config.eos_token_id,
         pad_token_id=hf_model.config.pad_token_id,
     )
-    count_parameters = lambda m: sum(p.numel() for p in m.parameters())
+
+    def count_parameters(m):
+        return sum(p.numel() for p in m.parameters())
+
     assert count_parameters(hf_model_fms) == count_parameters(hf_model)
 
     hf_model.eval()

--- a/tests/models/hf_equivalence/test_llama.py
+++ b/tests/models/hf_equivalence/test_llama.py
@@ -2,8 +2,7 @@ import pytest
 import torch
 
 from fms.models import get_model
-from fms.models.hf.utils import to_hf_api
-from fms.models.llama import convert_hf_llama
+from fms.models.hf import to_hf_api
 from fms.testing.comparison import (
     HFModelSignatureParams,
     ModelSignatureParams,
@@ -38,7 +37,9 @@ def test_llama_7b_equivalence():
 
     # Test Parameter Count
 
-    count_parameters = lambda m: sum(p.numel() for p in m.parameters())
+    def count_parameters(m):
+        return sum(p.numel() for p in m.parameters())
+
     assert count_parameters(hf_model_fms) == count_parameters(hf_model)
 
     # Test Model Signatures
@@ -98,5 +99,5 @@ def test_llama_7b_equivalence():
 
     torch._assert(
         math.isclose(hf_model_loss.item(), hf_model_fms_loss.item(), abs_tol=1e-3),
-        f"model loss is not equal",
+        "model loss is not equal",
     )

--- a/tests/models/hf_equivalence/test_roberta.py
+++ b/tests/models/hf_equivalence/test_roberta.py
@@ -23,7 +23,7 @@ from fms.testing.comparison import (
 
 def test_roberta_base_for_masked_lm_equivalency():
     # create models
-    hf_model = AutoModelForMaskedLM.from_pretrained("roberta-base")
+    hf_model = AutoModelForMaskedLM.from_pretrained("roberta-base", device_map="cpu")
 
     with tempfile.TemporaryDirectory() as workdir:
         hf_model.save_pretrained(
@@ -37,6 +37,7 @@ def test_roberta_base_for_masked_lm_equivalency():
             "hf",
             norm_eps=1e-5,
             tie_heads=True,
+            device_type="cpu",
         )
 
     # test the param count is the same before we load hf fms model
@@ -90,7 +91,9 @@ def test_roberta_base_for_masked_lm_equivalency():
         unmasker = pipeline("fill-mask", model=hf_model, tokenizer=tokenizer)
         hf_output = unmasker(prompt)
 
-        unmasker = pipeline("fill-mask", model=hf_model_fms, tokenizer=tokenizer)
+        unmasker = pipeline(
+            "fill-mask", model=hf_model_fms, tokenizer=tokenizer, device="cpu"
+        )
         hf_fms_output = unmasker(prompt)
 
     for res_hf, res_hf_fms in zip(hf_output, hf_fms_output):
@@ -113,7 +116,7 @@ def test_roberta_base_for_masked_lm_equivalency():
 
     torch._assert(
         math.isclose(hf_model_loss.item(), hf_model_fms_loss.item(), abs_tol=1e-3),
-        f"model loss is not equal",
+        "model loss is not equal",
     )
 
 
@@ -132,7 +135,8 @@ sequence_classification_params = [
 def test_roberta_base_for_sequence_classification(task, problem_type):
     # create models
     hf_model = AutoModelForSequenceClassification.from_pretrained(
-        "SamLowe/roberta-base-go_emotions"
+        "SamLowe/roberta-base-go_emotions",
+        device_map="cpu",
     )
     hf_model.config.problem_type = problem_type
     with torch.no_grad():
@@ -150,6 +154,7 @@ def test_roberta_base_for_sequence_classification(task, problem_type):
             "hf",
             norm_eps=1e-5,
             tie_heads=True,
+            device_type="cpu",
         )
 
     # copy weights
@@ -181,7 +186,9 @@ def test_roberta_base_for_sequence_classification(task, problem_type):
         hf_output = classifier(prompt)
         print(hf_output)
 
-        classifier = pipeline(task=task, model=hf_model_fms, tokenizer=tokenizer)
+        classifier = pipeline(
+            task=task, model=hf_model_fms, tokenizer=tokenizer, device="cpu"
+        )
         hf_fms_output = classifier(prompt)
         print(hf_fms_output)
 
@@ -191,7 +198,7 @@ def test_roberta_base_for_sequence_classification(task, problem_type):
 
     # test loss
     inputs = torch.arange(0, 16).unsqueeze(0)
-    if problem_type is "single_label_classification":
+    if problem_type == "single_label_classification":
         labels = torch.randint(high=hf_model.config.num_labels, size=(1,))
     else:
         labels = torch.randn(hf_model.config.num_labels).unsqueeze(0)
@@ -206,5 +213,5 @@ def test_roberta_base_for_sequence_classification(task, problem_type):
     print(hf_model_fms_loss)
     torch._assert(
         math.isclose(hf_model_loss.item(), hf_model_fms_loss.item(), abs_tol=1e-3),
-        f"model loss is not equal",
+        "model loss is not equal",
     )

--- a/tests/models/test_getmodel_fusedweights.py
+++ b/tests/models/test_getmodel_fusedweights.py
@@ -135,7 +135,7 @@ class TestUnfuseStrategy:
     def test_gptq_fusion_no_ckpt(self, get_gptq_state_dict):
         # validate fused/unfused output after instantiating GPTQ model without ckpt
         sd, strategy = get_gptq_state_dict
-        fusion = "fused" if strategy == True else "unfused"
+        fusion = "fused" if strategy else "unfused"
         expected_layers = expected_layers_from_fusion[fusion]
         assert all(
             [

--- a/tests/models/test_gpt_bigcode.py
+++ b/tests/models/test_gpt_bigcode.py
@@ -122,6 +122,7 @@ class GPTBigCodeGPTQFixtures(ModelFixtureMixin):
             return None
 
 
+@pytest.mark.autogptq
 class TestGPTBigCodeGPTQ(
     ModelConsistencyTestSuite, ModelCompileTestSuite, GPTBigCodeGPTQFixtures
 ):

--- a/tests/models/test_granite.py
+++ b/tests/models/test_granite.py
@@ -104,6 +104,7 @@ class GraniteGPTQFixtures(ModelFixtureMixin):
             return None
 
 
+@pytest.mark.autogptq
 class TestGraniteGPTQ(
     ModelConsistencyTestSuite, ModelCompileTestSuite, GraniteGPTQFixtures
 ):

--- a/tests/models/test_llama.py
+++ b/tests/models/test_llama.py
@@ -145,6 +145,7 @@ class LLaMA2GPTQFixtures(ModelFixtureMixin):
             return None
 
 
+@pytest.mark.autogptq
 class TestLlama2GPTQ(
     ModelConsistencyTestSuite, ModelCompileTestSuite, LLaMA2GPTQFixtures
 ):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -91,6 +91,7 @@ def test_getmodel():
     assert micro.config.nlayers == 5
 
 
+@pytest.mark.autogptq
 def test_uninitialized_module():
     model = models._get_model_instance(
         architecture="llama",
@@ -158,7 +159,7 @@ def test_load():
         newsd = serialization.load_state_dict(d)
         as_loaded = models.get_model("llama", "micro", d).state_dict()
         # this style load, layer-sharded, has to stitch together the state dicts.
-        assert type(newsd) == ChainMap
+        assert type(newsd) is ChainMap
         for key in keys:
             assert key in newsd
             torch.testing.assert_close(sd[key], as_loaded[key])

--- a/tests/models/test_roberta.py
+++ b/tests/models/test_roberta.py
@@ -99,6 +99,7 @@ class RoBERTaGPTQFixtures(ModelFixtureMixin):
         return None
 
 
+@pytest.mark.autogptq
 class TestRoBERTaGPTQ(
     ModelConsistencyTestSuite, ModelCompileTestSuite, RoBERTaGPTQFixtures
 ):

--- a/tests/modules/test_embedding.py
+++ b/tests/modules/test_embedding.py
@@ -1,5 +1,3 @@
-import math
-
 import torch
 
 from fms.modules.embedding import WordEmbedding
@@ -23,9 +21,9 @@ def test_abs_pos_padding():
             x_pad = x[:insert] + [pad_id] + x[insert:]
             y = m(torch.IntTensor(x).unsqueeze(0)).flatten().tolist()
             y_pad = m(torch.IntTensor(x_pad).unsqueeze(0)).flatten().tolist()
-            assert y_pad[insert] == 0, f"Output pad token {y_pad[i]} is non-zero"
+            assert y_pad[insert] == 0, f"Output pad token {y_pad[insert]} is non-zero"
             y_ = y_pad[:insert] + y_pad[insert + 1 :]
             for i in range(len(y)):
-                assert (
-                    y[i] == y_[i]
-                ), f"Index {i} of nonpadded output {y[i]} does not match padded output {y_[i]} with pad token {pad_id}"
+                assert y[i] == y_[i], (
+                    f"Index {i} of nonpadded output {y[i]} does not match padded output {y_[i]} with pad token {pad_id}"
+                )

--- a/tests/modules/test_positions.py
+++ b/tests/modules/test_positions.py
@@ -45,9 +45,7 @@ class RotaryEmbeddingTests(unittest.TestCase):
         )  # b s h e
         k = 2 * torch.tensor([[1, 0], [1, 0]], dtype=torch.float).unsqueeze(
             0
-        ).unsqueeze(
-            2
-        )  # b s h e
+        ).unsqueeze(2)  # b s h e
         rotary_embeddings = RotaryEmbedding(2, ratio=1, max_seq_len=2)
 
         qr, kr = rotary_embeddings.adjusted_qk(q, k)
@@ -87,7 +85,6 @@ class RotaryEmbeddingTests(unittest.TestCase):
         qr = qr.transpose(1, 2)  # b h s e
         kr = kr.transpose(1, 2)  # b h s e
 
-        orig_dotp = q @ k.transpose(2, 3)
         rotated_dotp = qr @ kr.transpose(2, 3)
 
         # If two pairs of k/q have the same dot product before rotation,

--- a/tests/triton/test_imports.py
+++ b/tests/triton/test_imports.py
@@ -1,11 +1,7 @@
 import sys
 
-import torch
-
 
 def test_triton_import():
-    import fms.models
-
     fms_triton_modules = [k for k in sys.modules.keys() if "fms.triton." in k]
 
     # The only fms.triton module allowed to be loaded in general should be pytorch ops

--- a/tests/utils/test_fusion.py
+++ b/tests/utils/test_fusion.py
@@ -1,4 +1,3 @@
-import pytest
 import torch.testing
 
 from fms.modules.attention import FusedQKV, MultiHeadAttention, UnfusedQKV

--- a/tests/utils/test_generate.py
+++ b/tests/utils/test_generate.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 import torch.nn.functional as F
 from torch import nn

--- a/tests/utils/test_gptq.py
+++ b/tests/utils/test_gptq.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from fms.models import get_model
+import fms.utils.gptq  # noqa: F401
 
 
 try:

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 import torch
-from safetensors import safe_open
 from safetensors.torch import save_file
 
 from fms.utils import serialization

--- a/tests/utils/test_tensors.py
+++ b/tests/utils/test_tensors.py
@@ -35,7 +35,7 @@ def test_expandable_tensor_ops():
     t.add_(7)
     torch.testing.assert_close(expandable, t)
     # in place op preserves type, no copy
-    assert type(expandable) == ExpandableTensor
+    assert type(expandable) is ExpandableTensor
 
 
 def test_cat():
@@ -52,8 +52,8 @@ def test_cat():
         expandable = torch.cat((expandable, to_append), dim=2)
 
     torch.testing.assert_close(expandable, expected)
-    assert type(expected) != ExpandableTensor
-    assert type(expandable) == ExpandableTensor
+    assert type(expected) is not ExpandableTensor
+    assert type(expandable) is ExpandableTensor
     assert expandable._underlying_tensor.shape[2] == 20
 
     # original should not have changed
@@ -92,4 +92,4 @@ def test_contiguous():
 
     torch.testing.assert_close(expandable, t)
     assert expandable.is_contiguous()
-    assert type(expandable) != ExpandableTensor
+    assert type(expandable) is not ExpandableTensor


### PR DESCRIPTION
This PR upgrades pytorch to 2.5.1, transformers to 4.48.3, and makes changes to ensure all tests still pass.

As part of this upgrade, this also updates GH actions to run more modern linting (ruff) on a newer python stack (3.12).