### PR TITLE
Fixed mypy failure in CI

### DIFF
--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -163,13 +163,13 @@ def _infer_model_configuration(
             ignore_patterns = None
 
         model_path = snapshot_download(
-            repo_id=model_id_or_path,
+            repo_id=str(model_id_or_path),
             ignore_patterns=ignore_patterns,
             allow_patterns=allow_patterns,
             cache_dir=os.environ.get("HF_HOME", None),
         )
     else:
-        model_path = model_id_or_path
+        model_path = str(model_id_or_path)
 
     config = AutoConfig.from_pretrained(model_path)
 


### PR DESCRIPTION
wrapped `model_id_or_path` in str to fix mypy issue with transformers