### PR TITLE
Fixed issues inferring Roberta QA as well as added features for encoder-only testing

### DIFF
--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -184,6 +184,15 @@ def _infer_model_configuration(
         config_params["p_dropout"] = config.hidden_dropout_prob
         config_params["norm_eps"] = config.layer_norm_eps
         config_params["activation_fn"] = config.hidden_act
+    elif architecture == "RobertaForQuestionAnswering":
+        inner_dim = config.intermediate_size
+        architecture = "roberta_question_answering"
+        config_params["emb_dim"] = config.hidden_size
+        config_params["pad_id"] = config.pad_token_id
+        config_params["max_pos"] = config.max_position_embeddings - 2
+        config_params["p_dropout"] = config.hidden_dropout_prob
+        config_params["norm_eps"] = config.layer_norm_eps
+        config_params["activation_fn"] = config.hidden_act
     elif architecture == "GraniteForCausalLM":
         inner_dim = config.intermediate_size
         architecture = "granite"

--- a/fms/testing/comparison.py
+++ b/fms/testing/comparison.py
@@ -98,8 +98,6 @@ def get_signature(
         if logits_getter_fn:
             p = logits_getter_fn(p)
 
-        # Temporary dummy backward pass to avoid checkpointing problems (see issue #591)
-        p.abs().mean().mul(0).backward()
         return p
 
     # If cuda is available, we want to always create a signature using fp32, so this will ensure that.
@@ -123,6 +121,7 @@ def compare_model_signatures(
     model_params_1: ModelSignatureParams,
     model_params_2: ModelSignatureParams,
     atol: float = 1e-3,
+    rtol: float = 1e-5,
 ):
     """This utility function will compare the signature between 2 models using np.allclose
 
@@ -157,6 +156,5 @@ def compare_model_signatures(
 
     signature = np.array(signature)
     signature2 = np.array(signature2)
-    assert np.allclose(signature, signature2, atol=atol), np.mean(
-        np.abs(signature2 - signature)
-    )
+    result_text = f"\nabs mean: {np.mean(np.abs(signature2 - signature))}\nsignature 1: {signature}\nsignature 2: {signature2}"
+    assert np.allclose(signature, signature2, atol=atol, rtol=rtol), result_text

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 def pad_input_ids(
-    input_ids_list: List[torch.Tensor], min_pad_length: int = 0
+    input_ids_list: List[torch.Tensor],
+    min_pad_length: int = 0,
+    is_causal_mask=True,
 ) -> Tuple[torch.Tensor, MutableMapping[str, Any]]:
     """
     Convert a list of Tensors to a rectangular tensor. Return extra padding kwargs for the position_ids and mask, since
@@ -59,8 +61,10 @@ def pad_input_ids(
     input_ids = torch.stack(padded_input_ids_list)
     padding_kwargs = {}
     mask = torch.stack(mask_list)
+    mask = mask.unsqueeze(-1) == mask.unsqueeze(-2)
     # this is a causal mask for generation
-    mask = (mask.unsqueeze(-1) == mask.unsqueeze(-2)).tril()
+    if is_causal_mask:
+        mask = mask.tril()
     mask = torch.where(mask.logical_not(), -torch.inf, 0.0)
     padding_kwargs["mask"] = mask
 


### PR DESCRIPTION
- Roberta for question-answering can now be inferred
- pad_input_ids no longer assumes a causal mask (is_causal_mask bool)
- comparison function for signatures now also takes the rtol param (defaulted to same as np.allclose)
- removed the backward call in `get_signature` as it is no longer required