### PR TITLE
Add fixes for full dynamic with masks

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Any, Callable, List, MutableMapping, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, List, MutableMapping, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -132,7 +132,7 @@ def _make_cache_dynamic(
     # kv updates are required for torch.compile with
     # mode='reduce-overhead'
     for layer in past_key_value_states:
-        if isinstance(layer, (tuple, list)):
+        if isinstance(layer, Iterable):
             for tensor in layer:
                 torch._dynamo.mark_dynamic(tensor, 2)
     return past_key_value_states

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -92,6 +92,8 @@ def __update_padding_kwargs(
             dim=2,
         )
         model_specific_kwargs["mask"] = mask
+        if torch._dynamo.config.dynamic_shapes:
+            torch._dynamo.mark_dynamic(mask, 2)
 
     # extend the position_ids
     position_ids = model_specific_kwargs.get("position_ids", None)
@@ -130,7 +132,7 @@ def _make_cache_dynamic(
     # kv updates are required for torch.compile with
     # mode='reduce-overhead'
     for layer in past_key_value_states:
-        if isinstance(layer, tuple):
+        if isinstance(layer, (tuple, list)):
             for tensor in layer:
                 torch._dynamo.mark_dynamic(tensor, 2)
     return past_key_value_states


### PR DESCRIPTION
This PR fixes generation code with torch.compile() and dynamic shapes when masks are in play. Before, we would get 3 compiled graphs due to the mask not being detected as dynamic early enough. Now, the issue is gone. Also, it covers an edge case where the kv cache is a list and not a tuple.