### PR TITLE
Add support for fms_mo-based INT8 Granite

### DIFF
--- a/fms/models/granite.py
+++ b/fms/models/granite.py
@@ -12,7 +12,7 @@ from fms.distributed.strategy import DistributedStrategy, NoOpStrategy
 from fms.modules.attention import MultiHeadAttention
 from fms.modules.feedforward import GatedLinearUnit
 from fms.modules.layernorm import LayerNormParameterized
-from fms.modules.linear import get_linear_type_str
+from fms.modules.linear import get_linear_type
 from fms.modules.positions import RotaryEmbedding
 from fms.utils import serialization
 from fms.utils.activation import str_to_activation
@@ -482,7 +482,7 @@ serialization.register_adapter_step(
 def _get_rope_params(linear_type: str) -> list[str]:
     if "gptq" in linear_type:
         return ["qweight", "scales", "qzeros", "bias"]
-    elif "int8" in linear_type:
+    if "int8" in linear_type:
         # quantize_weight is fms-model-optimizer identifier of weight clip values
         return ["weight", "bias", "quantize_weight"]
     else:  # torch.nn.Linear
@@ -498,9 +498,8 @@ def _hf_to_fms_rope(
         head_size = model_config.emb_dim // model_config.nheads
         linear_type_str = "torch_linear"
         if model_config.linear_config:
-            linear_type = model_config.linear_config["linear_type"]
-            linear_type_str = get_linear_type_str(
-                linear_type,
+            linear_type_str = get_linear_type(
+                model_config.linear_config,
                 module_name=None,  # if callable, linear_type should return default str
             )
     else:

--- a/fms/modules/linear.py
+++ b/fms/modules/linear.py
@@ -48,22 +48,12 @@ def get_all_linear_type_to_sharding_maps() -> dict[str, Callable]:
     return __type_sharding_map
 
 
-def get_linear_type(
-    linear_config: Optional[Mapping[str, Any]], module_name: Optional[str] = None
+def get_linear_type_str(
+    linear_type: str | Callable | None, module_name: str | None = None
 ) -> str:
-    """Parse linear configuration mapping to extract selected linear type from
-    `linear_config['linear_type']`.
-    `linear_type` can be string, callable, or None. Callable is a user-provided function
-    to select linear type based on module name. It should return string or None.
-    When no configuration is provided or linear type is None, we default to
-    "torch_linear" type, which maps to torch.nn.Linear.
-    """
-    if not linear_config:
-        return "torch_linear"
+    """Parse linear_type and return its string version."""
 
-    linear_type = linear_config.get("linear_type", None)
-
-    if not linear_type:
+    if linear_type is None:
         return "torch_linear"
 
     linear_type_str = None
@@ -100,6 +90,22 @@ def get_linear_type(
     raise ValueError(
         "linear_type must be either a supported string or a module-selection function."
     )
+
+
+def get_linear_type(
+    linear_config: Optional[Mapping[str, Any]], module_name: Optional[str] = None
+) -> str:
+    """Parse linear configuration mapping to extract selected linear type from
+    `linear_config['linear_type']`.
+    `linear_type` can be string, callable, or None. Callable is a user-provided function
+    to select linear type based on module name. It should return string or None.
+    When no configuration is provided or linear type is None, we default to
+    "torch_linear" type, which maps to torch.nn.Linear.
+    """
+    if linear_config is None:
+        return "torch_linear"
+    linear_type = linear_config.get("linear_type", None)
+    return get_linear_type_str(linear_type, module_name)
 
 
 class UninitializedLinear(UninitializedModule):

--- a/fms/modules/linear.py
+++ b/fms/modules/linear.py
@@ -48,12 +48,22 @@ def get_all_linear_type_to_sharding_maps() -> dict[str, Callable]:
     return __type_sharding_map
 
 
-def get_linear_type_str(
-    linear_type: str | Callable | None, module_name: str | None = None
+def get_linear_type(
+    linear_config: Optional[Mapping[str, Any]], module_name: Optional[str] = None
 ) -> str:
-    """Parse linear_type and return its string version."""
+    """Parse linear configuration mapping to extract selected linear type from
+    `linear_config['linear_type']`.
+    `linear_type` can be string, callable, or None. Callable is a user-provided function
+    to select linear type based on module name. It should return string or None.
+    When no configuration is provided or linear type is None, we default to
+    "torch_linear" type, which maps to torch.nn.Linear.
+    """
+    if not linear_config:
+        return "torch_linear"
 
-    if linear_type is None:
+    linear_type = linear_config.get("linear_type", None)
+
+    if not linear_type:
         return "torch_linear"
 
     linear_type_str = None
@@ -90,22 +100,6 @@ def get_linear_type_str(
     raise ValueError(
         "linear_type must be either a supported string or a module-selection function."
     )
-
-
-def get_linear_type(
-    linear_config: Optional[Mapping[str, Any]], module_name: Optional[str] = None
-) -> str:
-    """Parse linear configuration mapping to extract selected linear type from
-    `linear_config['linear_type']`.
-    `linear_type` can be string, callable, or None. Callable is a user-provided function
-    to select linear type based on module name. It should return string or None.
-    When no configuration is provided or linear type is None, we default to
-    "torch_linear" type, which maps to torch.nn.Linear.
-    """
-    if linear_config is None:
-        return "torch_linear"
-    linear_type = linear_config.get("linear_type", None)
-    return get_linear_type_str(linear_type, module_name)
 
 
 class UninitializedLinear(UninitializedModule):


### PR DESCRIPTION
This PR adds support for INT8 (W8A8) Granite-3.X models generated with `fms-model-optimizer`.
In particular, Granite architecture also necessitates the HF-to-FMS RoPE transpose of K,V weights _and corresponding INT8 quantization parameters_ (like in GPTQ).

Additional details:

1. Weight quantization "per-channel" will generate a `quantize_weight.clip_val` in the input state dictionary, which is used to apply quantization along the out_feat weight dimension (1 clip per output feature). As this dimension is transposed, this `clip_val` needs to be transposed accordingly.
2. Weight quantization "per-tensor" will generate a single clip that applies to the full tensor. Transpose should not be applied to this parameter (hence the check `param.numel() > 1`).
3. Smoothquant applies scaling along the input feature, so it is not impacted by the transpose operation either.

This PR also adds support for a _callable_ `linear_type` within `_hf_to_fms_rope` adapter step, which previously supported string type only.
