### PR TITLE
Fix extra graph generation during generate with contiguous cache

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -117,7 +117,7 @@ def _make_cache_contiguous(
     # kv updates are required for torch.compile with
     # mode='reduce-overhead'
     n_kv_s: list[Iterable[torch.Tensor] | SSMCacheUnit] = []
-    for layer_idx, layer_cache in enumerate(past_key_value_states):
+    for layer_cache in past_key_value_states:
         if (
             isinstance(layer_cache, Iterable)
             and all(

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, Iterable, List, MutableMapping, Optional, Tupl
 import torch
 import torch.nn.functional as F
 
+from fms.modules.ssm import SSMCacheUnit
+
 
 logger = logging.getLogger(__name__)
 
@@ -110,13 +112,12 @@ def __update_padding_kwargs(
 
 
 def _make_cache_contiguous(
-    past_key_value_states: List[List[torch.Tensor]],
-) -> List[List[torch.Tensor]]:
+    past_key_value_states: list[Iterable[torch.Tensor] | SSMCacheUnit],
+) -> list[Iterable[torch.Tensor] | SSMCacheUnit]:
     # kv updates are required for torch.compile with
     # mode='reduce-overhead'
-    n_kv_s: List[List[torch.Tensor]] = []
+    n_kv_s: list[Iterable[torch.Tensor] | SSMCacheUnit] = []
     for layer_idx, layer_cache in enumerate(past_key_value_states):
-        # n_kv_s.append([])
         if (
             isinstance(layer_cache, Iterable)
             and all(

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -128,12 +128,16 @@ def _make_cache_contiguous(
                 or not past_key_value_states[layer_idx][1].is_contiguous()
             )
         ):
-            for tensor_idx in range(len(past_key_value_states[layer_idx])):
-                n_kv_s[layer_idx].append(
-                    past_key_value_states[layer_idx][tensor_idx]
+            n_kv_s[layer_idx] = tuple(
+                [
+                    past_key_value_states[layer_idx][0]
                     .clone(memory_format=torch.contiguous_format)
-                    .detach()
-                )
+                    .detach(),
+                    past_key_value_states[layer_idx][1]
+                    .clone(memory_format=torch.contiguous_format)
+                    .detach(),
+                ]
+            )
         else:
             n_kv_s[layer_idx] = past_key_value_states[layer_idx]
     return n_kv_s


### PR DESCRIPTION
This avoids a 3rd graph generation during `generate()` with dynamic shapes, now for real