### PR TITLE
Add handling of token_type_ids to RoBERTa

### DIFF
--- a/fms/models/roberta.py
+++ b/fms/models/roberta.py
@@ -32,6 +32,7 @@ class RoBERTaConfig(ModelConfig):
     activation_fn: str = "gelu"
     classifier_activation_fn: str = "tanh"
     max_pos: int = 512
+    type_vocab_size: int = 1
     p_dropout: float = 0.1
     multiquery_attn: bool = False
     norm_eps: float = 1e-12
@@ -146,6 +147,11 @@ class RoBERTaHeadless(nn.Module):
             final_layers=True,
         )
 
+        self.token_type_embeddings = nn.Embedding(
+            self.config.type_vocab_size,
+            self.config.emb_dim,
+        )
+
         self.enc_norm = self.distributed_strategy.distribute_module(
             nn.LayerNorm(self.config.emb_dim, eps=self.config.norm_eps),
             final_layers=True,
@@ -161,6 +167,7 @@ class RoBERTaHeadless(nn.Module):
                 mean=0.0,
                 std=self.config.emb_dim**-0.5,
             )
+        nn.init.zeros_(self.token_type_embeddings.weight)
         for layer in self.layers:
             for sublayer in ["ln", "ff_ln", "attn", "ff_sub_layer"]:
                 getattr(layer, sublayer).reset_parameters()
@@ -171,6 +178,7 @@ class RoBERTaHeadless(nn.Module):
         x: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
         attn_algorithm: Optional[str] = None,
     ):
         if mask is None:
@@ -200,8 +208,16 @@ class RoBERTaHeadless(nn.Module):
         if self.config.pad_id is not None:
             position_out = position_out.mul(~is_pad.unsqueeze(-1))
 
-        # perform absolute position embedding
-        x = x_emb + position_out
+        if token_type_ids is None:
+            token_type_ids = torch.zeros(
+                x.size(),
+                dtype=torch.long,
+                device=x.device,
+            )
+        token_type_out = self.token_type_embeddings(token_type_ids)
+
+        # perform absolute position embedding, including token type embeddings
+        x = x_emb + token_type_out + position_out
 
         # layer norm
         x = self.enc_norm(x)
@@ -259,11 +275,16 @@ class RoBERTa(nn.Module):
         x: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
         attn_algorithm: Optional[str] = None,
     ):
         # run through the encoder layers
         x = self.base_model(
-            x, mask=mask, position_ids=position_ids, attn_algorithm=attn_algorithm
+            x,
+            mask=mask,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+            attn_algorithm=attn_algorithm,
         )
 
         # run through classification head and project to vocab space
@@ -340,11 +361,16 @@ class RoBERTaForQuestionAnswering(nn.Module):
         x: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
         attn_algorithm: Optional[str] = None,
     ):
         # run through the encoder layers
         x = self.base_model(
-            x, mask=mask, position_ids=position_ids, attn_algorithm=attn_algorithm
+            x,
+            mask=mask,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+            attn_algorithm=attn_algorithm,
         )
 
         # run head and process outputs
@@ -449,6 +475,10 @@ def _hf_to_fms_names(hf_sd: Mapping[str, Any], **kwargs) -> Mapping[str, Any]:
         (
             r"^roberta.embeddings.position_embeddings.weight",
             "base_model.position_embedding.weight",
+        ),
+        (
+            r"^roberta.embeddings.token_type_embeddings.weight",
+            "base_model.token_type_embeddings.weight",
         ),
         (r"^roberta.embeddings.LayerNorm", "base_model.enc_norm"),
         (r"^roberta.encoder.layer", "base_model.layers"),

--- a/fms/models/roberta.py
+++ b/fms/models/roberta.py
@@ -208,6 +208,9 @@ class RoBERTaHeadless(nn.Module):
         if self.config.pad_id is not None:
             position_out = position_out.mul(~is_pad.unsqueeze(-1))
 
+        # token_type_ids should be of size (bs, seq_len), same as input_ids.
+        # depending on task, it may be a zero tensor, but the embeddings may not be,
+        # especially if fine-tuned, returning non-zero token_type_out
         if token_type_ids is None:
             token_type_ids = torch.zeros(
                 x.size(),

--- a/tests/models/hf_equivalence/test_roberta.py
+++ b/tests/models/hf_equivalence/test_roberta.py
@@ -42,10 +42,9 @@ def test_roberta_base_for_masked_lm_equivalency():
 
     # test the param count is the same before we load hf fms model
     model_param_count = sum([p.numel() for p in model.parameters()])
-    # note: we subtract 3*768 for the following reasons:
-    #     1x768 - our model does not have a token_type_embeddings as part of its embeddings
-    #     2x768 - our model uses 512 positional encodings instead of 514 (they don't use their position 0, and their position 1 is the zeros vector)
-    hf_model_param_count = sum([p.numel() for p in hf_model.parameters()]) - 3 * 768
+    # note: we subtract 2*768 because our model uses 512 positional encodings instead
+    # of 514 (they don't use their position 0, and their position 1 is the zeros vector)
+    hf_model_param_count = sum([p.numel() for p in hf_model.parameters()]) - 2 * 768
     assert model_param_count == hf_model_param_count
 
     hf_model_fms = to_hf_api(


### PR DESCRIPTION
This PR adds a `token_type_embeddings` layer to RoBERTa in order to match the HF architecture for BERT / RoBERTa.
In some downstream tasks, `token_type_ids` are used to identify different sentences within a single input sequence, and processed via a `token_type_embeddings` layer.

While in some scenarios (such as in pre-trained RoBERTa) the token type embedding weights are zero, this is not always the case. For example, a fine-tuned model may have small, non-zero token_type_ids embedding weights even if the task does not strictly require them.

Adding a `token_type_embeddings` layer also fixes the warning for missed key when loading an HF/FMS-MO trained checkpoint into FMS/FMS-MO architecture:
```[WARNING] Keys from checkpoint (adapted to FMS) not copied into model: {'roberta.embeddings.token_type_embeddings.weight'}```
