### PR TITLE
Raise exception in case of shape mismatch during ckpt loading

### DIFF
--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -629,7 +629,15 @@ def _load_partial_state_dict(
                     )
                 )
                 unused_keys_tp = tp_module.load_weights(tensor_values)
-        except:  # noqa: E722
+        except Exception as e:
+            # capture error specific to shape mismatch and halt the processing
+            if "shape" in str(e) or "size" in str(e):
+                raise ValueError(
+                    "Shape mismatch encountered while copying a tensor from the provided "
+                    "checkpoint into the model.\nIf running a quantized model, it may "
+                    "mean that the quantization setup used to train the checkpoint does "
+                    "not match the one used to instantiate the model."
+                ) from e
             if unused_keys_tp:
                 unused_keys.update(unused_keys_tp)
             else:


### PR DESCRIPTION
During the loading of parameters from a checkpoint into a newly instantiated FMS architecture, the current behavior is "semi-silent": processing of other parameters will continue, the keyword corresponding to the parameter that failed is recorded in `unused_keys`, and the full list of unused keys is listed as warning printed out at the end of the checkpoint copy.

This behavior is undesirable for quantized models, where mismatch due to using a different quantization configurations between the trained checkpoint and the FMS architecture can go unnoticed. In this scenario, it is preferable to stop the checkpoint copy and raise an error.

As mismatched quantization configurations should result in a shape/size error during the copy (for example, when a per-channel quantization parameter from checkpoint is being copied on a per-tensor parameter in the model), this PR introduces a monitoring of the exception and raising of an error in case of size mismatch.
