### PR TITLE
Verification for unused layers to remove warnings

### DIFF
--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -127,6 +127,11 @@ def _infer_model_configuration(
             ):
                 ignore_patterns = ["*.safetensors"]
                 allow_patterns.append("*.pt")
+            elif isinstance(model_id_or_path, str) and model_id_or_path.startswith(
+                "mistralai/Mistral"
+            ):
+                ignore_patterns = ["consolidated.safetensors"]
+                allow_patterns.append("*.safetensors*")
             else:
                 allow_patterns.append("*.safetensors*")
         else:


### PR DESCRIPTION
Fixes the warning for many layer names that are not mapped into real modules names.

The issue is this warning that appears within every mistral inference:
```bash
[WARNING] Keys from checkpoint (adapted to FMS) not copied into model: {'layers.4.feed_forward.w3.weight', 'layers.29.ffn_norm.weight', 'layers.3.attention.wv.weight', 'layers.13.feed_forward.w2.weight', 'layers.0.ffn_norm.weight', 'layers.3.attention.wq.weight', 'layers.14.attention.wo.weight', 'layers.19.attention.wv.weight', 'layers.9.feed_forward.w1.weight', 'layers.26.feed_forward.w2.weight', 'layers.7.ffn_norm.weight', 'layers.31.attention.wq.weight', 'layers.8.feed_forward.w3.weight', 'layers.22.ffn_norm.weight', 'layers.8.ffn_norm.weight', 'layers.30.attention.wq.weight', 'layers.21.feed_forward.w3.weight', 'layers.16.attention.wo.weight', 'layers.10.feed_forward.w2.weight', 'layers.18.attention.wk.weight', 'layers.8.feed_forward.w1.weight', 'layers.29.attention.wq.weight', 'layers.18.attention.wq.weight', 'layers.6.attention.wv.weight', 'layers.16.ffn_norm.weight', 'layers.7.attention.wq.weight', 'layers.27.feed_forward.w2.weight', 'layers.25.attention.wk.weight', 'layers.2.attention_norm.weight', 'layers.4.attention.wv.weight', 'layers.19.feed_forward.w2.weight', 'layers.29.attention.wv.weight', 'layers.26.ffn_norm.weight', 'layers.3.feed_forward.w1.weight', 'layers.3.attention.wk.weight', 'layers.19.feed_forward.w1.weight', 'layers.27.attention.wo.weight', 'layers.30.feed_forward.w3.weight', 'layers.26.attention_norm.weight', 'layers.16.feed_forward.w3.weight', 'layers.5.feed_forward.w1.weight', 'layers.11.attention.wv.weight', 'layers.29.attention.wk.weight', 'layers.31.feed_forward.w3.weight', 'layers.2.feed_forward.w3.weight', 'layers.18.attention.wv.weight', 'layers.16.attention_norm.weight', 'layers.11.attention.wk.weight', 'layers.14.feed_forward.w2.weight', 'layers.28.ffn_norm.weight', 'layers.24.attention.wv.weight', 'layers.22.feed_forward.w3.weight', 'layers.14.feed_forward.w3.weight', 'layers.28.attention.wq.weight', 'layers.4.ffn_norm.weight', 'layers.7.feed_forward.w1.weight', 'layers.15.feed_forward.w1.weight', 'layers.16.attention.wv.weight', 'layers.0.attention.wk.weight', 'layers.10.attention.wv.weight', 'layers.27.attention.wq.weight', 'layers.2.ffn_norm.weight', 'layers.14.ffn_norm.weight', 'layers.17.attention.wq.weight', 'layers.18.attention.wo.weight', 'layers.7.attention_norm.weight', 'layers.1.attention.wv.weight', 'layers.11.feed_forward.w1.weight', 'layers.14.attention_norm.weight', 'layers.5.feed_forward.w3.weight', 'layers.17.attention_norm.weight', 'layers.15.attention.wk.weight', 'layers.10.feed_forward.w3.weight', 'layers.24.attention.wk.weight', 'layers.6.feed_forward.w2.weight', 'layers.12.feed_forward.w2.weight', 'layers.15.ffn_norm.weight', 'layers.19.attention.wk.weight', 'layers.29.feed_forward.w2.weight', 'layers.22.attention_norm.weight', 'layers.20.feed_forward.w1.weight', 'layers.9.attention.wk.weight', 'layers.13.attention.wk.weight', 'layers.11.feed_forward.w3.weight', 'layers.4.feed_forward.w1.weight', 'layers.17.attention.wo.weight', 'layers.15.attention.wq.weight', 'layers.1.attention_norm.weight', 'layers.21.attention.wk.weight', 'layers.6.ffn_norm.weight', 'layers.3.ffn_norm.weight', 'layers.10.attention_norm.weight', 'layers.1.feed_forward.w1.weight', 'layers.25.feed_forward.w1.weight', 'layers.28.attention_norm.weight', 'layers.13.attention_norm.weight', 'layers.11.attention.wo.weight', 'layers.24.attention.wq.weight', 'layers.14.attention.wk.weight', 'layers.21.attention.wv.weight', 'layers.9.feed_forward.w2.weight', 'layers.23.attention.wv.weight', 'layers.22.attention.wv.weight', 'layers.27.attention.wv.weight', 'layers.22.attention.wk.weight', 'layers.10.attention.wk.weight', 'layers.21.attention.wq.weight', 'layers.20.ffn_norm.weight', 'layers.26.attention.wk.weight', 'layers.24.feed_forward.w3.weight', 'layers.16.attention.wk.weight', 'layers.5.attention.wv.weight', 'layers.26.attention.wo.weight', 'layers.13.attention.wo.weight', 'layers.26.feed_forward.w1.weight', 'layers.10.feed_forward.w1.weight', 'layers.0.feed_forward.w2.weight', 'layers.26.attention.wv.weight', 'layers.5.ffn_norm.weight', 'layers.0.attention.wq.weight', 'layers.28.feed_forward.w2.weight', 'layers.28.attention.wk.weight', 'layers.31.ffn_norm.weight', 'layers.2.attention.wq.weight', 'layers.25.feed_forward.w3.weight', 'layers.3.feed_forward.w3.weight', 'layers.25.ffn_norm.weight', 'layers.14.attention.wv.weight', 'layers.6.feed_forward.w3.weight', 'layers.25.attention.wv.weight', 'layers.21.ffn_norm.weight', 'layers.23.attention.wo.weight', 'layers.20.attention.wo.weight', 'layers.24.attention_norm.weight', 'layers.19.feed_forward.w3.weight', 'layers.3.attention_norm.weight', 'layers.25.attention.wq.weight', 'layers.7.attention.wv.weight', 'layers.31.attention.wo.weight', 'layers.11.ffn_norm.weight', 'layers.4.attention_norm.weight', 'layers.22.attention.wq.weight', 'layers.12.ffn_norm.weight', 'layers.27.ffn_norm.weight', 'layers.18.feed_forward.w3.weight', 'layers.5.attention_norm.weight', 'layers.20.attention_norm.weight', 'layers.0.feed_forward.w3.weight', 'layers.6.attention.wk.weight', 'layers.17.attention.wv.weight', 'layers.29.feed_forward.w3.weight', 'layers.9.attention.wo.weight', 'layers.2.attention.wv.weight', 'layers.29.attention.wo.weight', 'layers.21.attention.wo.weight', 'layers.25.attention.wo.weight', 'layers.13.feed_forward.w1.weight', 'layers.13.attention.wv.weight', 'layers.5.attention.wq.weight', 'layers.27.feed_forward.w1.weight', 'layers.13.feed_forward.w3.weight', 'layers.22.attention.wo.weight', 'layers.31.attention_norm.weight', 'layers.26.feed_forward.w3.weight', 'layers.31.feed_forward.w1.weight', 'layers.22.feed_forward.w1.weight', 'layers.19.attention.wq.weight', 'layers.6.attention.wq.weight', 'layers.1.feed_forward.w3.weight', 'layers.20.feed_forward.w2.weight', 'layers.0.attention.wv.weight', 'layers.18.attention_norm.weight', 'layers.30.attention.wo.weight', 'layers.0.attention_norm.weight', 'layers.17.attention.wk.weight', 'layers.19.attention_norm.weight', 'layers.13.attention.wq.weight', 'layers.1.feed_forward.w2.weight', 'layers.29.attention_norm.weight', 'layers.10.attention.wo.weight', 'layers.6.feed_forward.w1.weight', 'layers.31.attention.wv.weight', 'layers.27.feed_forward.w3.weight', 'layers.30.ffn_norm.weight', 'layers.30.attention.wv.weight', 'layers.31.attention.wk.weight', 'output.weight', 'layers.17.feed_forward.w3.weight', 'layers.8.attention.wk.weight', 'layers.28.attention.wv.weight', 'layers.29.feed_forward.w1.weight', 'layers.7.attention.wo.weight', 'layers.21.feed_forward.w1.weight', 'layers.6.attention_norm.weight', 'layers.22.feed_forward.w2.weight', 'layers.20.feed_forward.w3.weight', 'layers.7.attention.wk.weight', 'layers.2.feed_forward.w2.weight', 'layers.4.attention.wo.weight', 'norm.weight', 'layers.16.feed_forward.w1.weight', 'layers.20.attention.wv.weight', 'layers.4.attention.wk.weight', 'layers.23.attention_norm.weight', 'layers.26.attention.wq.weight', 'layers.15.attention.wv.weight', 'layers.17.ffn_norm.weight', 'layers.8.attention.wq.weight', 'layers.13.ffn_norm.weight', 'layers.12.attention.wv.weight', 'layers.7.feed_forward.w2.weight', 'layers.8.attention_norm.weight', 'layers.1.attention.wq.weight', 'layers.12.attention.wq.weight', 'layers.17.feed_forward.w1.weight', 'layers.9.attention.wq.weight', 'layers.20.attention.wk.weight', 'layers.1.attention.wk.weight', 'layers.6.attention.wo.weight', 'layers.3.attention.wo.weight', 'layers.10.ffn_norm.weight', 'layers.28.attention.wo.weight', 'layers.4.feed_forward.w2.weight', 'layers.3.feed_forward.w2.weight', 'layers.18.ffn_norm.weight', 'layers.15.attention_norm.weight', 'layers.17.feed_forward.w2.weight', 'layers.23.ffn_norm.weight', 'layers.11.attention.wq.weight', 'layers.21.attention_norm.weight', 'layers.15.feed_forward.w2.weight', 'layers.2.attention.wk.weight', 'layers.30.attention_norm.weight', 'layers.9.attention_norm.weight', 'layers.16.attention.wq.weight', 'layers.1.attention.wo.weight', 'layers.28.feed_forward.w3.weight', 'layers.5.feed_forward.w2.weight', 'layers.20.attention.wq.weight', 'layers.12.attention.wo.weight', 'layers.23.feed_forward.w2.weight', 'layers.0.feed_forward.w1.weight', 'layers.31.feed_forward.w2.weight', 'layers.23.feed_forward.w1.weight', 'layers.12.feed_forward.w3.weight', 'layers.2.attention.wo.weight', 'layers.8.attention.wv.weight', 'layers.21.feed_forward.w2.weight', 'layers.28.feed_forward.w1.weight', 'layers.19.ffn_norm.weight', 'layers.12.attention_norm.weight', 'layers.15.feed_forward.w3.weight', 'layers.12.attention.wk.weight', 'layers.9.ffn_norm.weight', 'layers.18.feed_forward.w2.weight', 'layers.24.feed_forward.w2.weight', 'layers.30.attention.wk.weight', 'layers.19.attention.wo.weight', 'layers.24.attention.wo.weight', 'layers.11.feed_forward.w2.weight', 'layers.14.feed_forward.w1.weight', 'layers.23.attention.wq.weight', 'layers.11.attention_norm.weight', 'layers.4.attention.wq.weight', 'layers.12.feed_forward.w1.weight', 'layers.30.feed_forward.w1.weight', 'layers.18.feed_forward.w1.weight', 'layers.30.feed_forward.w2.weight', 'layers.10.attention.wq.weight', 'layers.24.ffn_norm.weight', 'layers.8.feed_forward.w2.weight', 'layers.27.attention.wk.weight', 'layers.25.attention_norm.weight', 'layers.24.feed_forward.w1.weight', 'layers.5.attention.wo.weight', 'layers.23.attention.wk.weight', 'layers.9.feed_forward.w3.weight', 'layers.23.feed_forward.w3.weight', 'layers.2.feed_forward.w1.weight', 'tok_embeddings.weight', 'layers.7.feed_forward.w3.weight', 'layers.5.attention.wk.weight', 'layers.0.attention.wo.weight', 'layers.1.ffn_norm.weight', 'layers.16.feed_forward.w2.weight', 'layers.8.attention.wo.weight', 'layers.14.attention.wq.weight', 'layers.15.attention.wo.weight', 'layers.25.feed_forward.w2.weight', 'layers.9.attention.wv.weight', 'layers.27.attention_norm.weight'}
```
Debugging this, I found that in [these lines in the serialization.py](https://github.com/foundation-model-stack/foundation-model-stack/blob/main/fms/utils/serialization.py#L572), in the model config there is no module correspondent that actually contains these layers that show up in the dict as unused.
As per the printed based debug lines following, these layers are added for no reason:

```bash
for key, tensor_value in state_dict.items():
layers.4.feed_forward.w1.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.attention.wq.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.attention.wk.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.attention_norm.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.attention.wv.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.ffn_norm.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.feed_forward.w2.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
layers.4.attention.wo.weight
while key_step < len(key_steps) - 1:
0
for key, tensor_value in state_dict.items():
base_model.dec_norm.weight
while key_step < len(key_steps) - 1:
0
```

The inference scripts run normally with these changes suggested, without any warning:
```bash
$ python scripts/inference.py --architecture=hf_pretrained --variant="mistralai/Mistral-7B-Instruct-v0.3" --tokenizer="mistralai/Mistral-7B-Instruct-v0.3" --unfuse_weights --fixed_prompt_length 64 --max_new_tokens=5 --output_path=/tmp/debug/test --compile --device=aiu --default_dtype=fp16 --timing per-token

[ 0/ 1]: Namespace(device_type='aiu', architecture='hf_pretrained', variant='mistralai/Mistral-7B-Instruct-v0.3', model_path=None, model_source=None, quantization=None, int8_weight_per_channel=False, int8_activ_quant_type='per_token', int8_smoothquant=False, tokenizer='mistralai/Mistral-7B-Instruct-v0.3', no_use_cache=True, unfuse_weights=True, default_dtype='fp16', compile=True, compile_mode='default', compile_backend='inductor', compile_dynamic=False, compile_dynamic_sendnn=False, deterministic=False, distributed=False, batch_size=1, max_prompt_length=None, min_pad_length=0, fixed_prompt_length=64, max_new_tokens=5, no_early_termination=False, prompt_type='chat', prompt_path='', output_path='/tmp/debug/test', timing='per-token', iters=1, verbose=0)
local sendnn
[ 0/ 1]: Sentient AIU: Enabled
[ 0/ 1]: NOTICE: Adjusting torch._dynamo.config.cache_size_limit from 8 to 160 to accomodate prompt size of 64 and decode tokens of 5
[ 0/ 1]: loading model
[ 0/ 1]: ============================================================
[ 0/ 1]: model_path=None
[ 0/ 1]: linear_config={'linear_type': 'torch_linear'}
[ 0/ 1]: fused_weights=False
[ 0/ 1]: data_type=torch.float16
[ 0/ 1]: ============================================================

Fetching 12 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 12/12 [00:00<00:00, 141381.03it/s]

2025/05/19 13:09:36 579995	INFO [flex_fused_device_node.hpp::Compute:87]	--- Completion of ScheduleCompute: ncbs=71 cbs_idstr=id.5
2025/05/19 13:09:36 580379	INFO [super_node_context.cpp::HandleCompletion:465]	HandleCompletion of 12
2025/05/19 13:09:36 580382	INFO [super_node_context.cpp::CleanupPerNmb:522]	Deallocating 
2025/05/19 13:09:36 580391	INFO [graph_loader.cpp::Predict:285]	Predicting on 0 finished
[ 0/ 1]: First-token latency: 145.915 ms
[ 0/ 1]: Average next-token latency: 157.018 ms
[ 0/ 1]: Average next-token latency (including first token): 154.797 ms
[ 0/ 1]: Max next-token latency: 157.127 ms (token #2)
[ 0/ 1]: Min next-token latency: 156.960 ms (token #3)
[ 0/ 1]: Std deviation of next-token latencies: 0.068 ms
[ 0/ 1]: Per-token timing information: 145.915, 157.127, 156.960, 156.962, 157.023 ms
[ 0/ 1]: Below is an instruction that describes a task. Write a response that appropriately completes the request.

### Instruction:
Provide a list of instructions for preparing chicken soup.

### Response:
1. Gather

2025/05/19 13:09:37 835830	INFO [pf_interface.cpp::usageremove:432]	PF interface ucount=0
2025/05/19 13:09:37 835843	INFO [pf_interface.cpp::~PfInterface:196]	Gathering final ECC statistics for SEN:VFIO:TYPE1:0000:40:00.0
2025/05/19 13:09:37 836259	INFO [vfio_hal_mci_ddr_init_util.cpp::ddr_ECC_error_report:1486]	ECC error count:  UE = 0  CE = 0
2025/05/19 13:09:37 836278	INFO [pf_interface.cpp::~PfInterface_impl:638]	Deleting PF Interface implementation
2025/05/19 13:09:37 836280	WARNING [pf_interface.cpp::~PfInterface_impl:642]	Stoping MSI monitor
2025/05/19 13:09:37 836400	WARNING [pf_msi_monitor.cpp::PollingThread:144]	PfMSIMonitor: Ending
2025/05/19 13:09:37 836506	WARNING [pf_interface.cpp::stop_monitor_thread:662]	Stopping monitor thread ...
2025/05/19 13:09:37 836647	INFO [pf_interface.cpp::~PfInterface_impl:656]	Pfinterface deleted.
```
My proposed change is to remove them, at loading time, but I do believe there are better ways to improve/fix this, so please advise! 

cc: @JRosenkranz