### PR TITLE
[llama] added dummy tie_weights for HF api

### DIFF
--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -372,6 +372,12 @@ class LLaMA(nn.Module):
 
         return dec_out, present_key_value_states
 
+    def tie_weights(self):
+        """
+        When HF api calls tie_weights, we can ignore for now because we use self.shared
+        """
+        pass
+
     def forward(
         self,
         x: torch.Tensor,


### PR DESCRIPTION
prevents HF from throwing error when function tie_weights doesn't exist