### PR TITLE
Don't set cache_dir in snapshot_download

### DIFF
--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -137,7 +137,6 @@ def _infer_model_configuration(
             repo_id=str(model_id_or_path),
             ignore_patterns=ignore_patterns,
             allow_patterns=allow_patterns,
-            cache_dir=os.environ.get("HF_HOME", None),
         )
     else:
         model_path = str(model_id_or_path)


### PR DESCRIPTION
Little QoL improvement to have the cache directory be defaulted by Transformers.

Setting `cache_dir` explicilty to `HF_HOME` if it exists causes a mismatch between Transformers and FMS. Without any other relevant env vars (eg. HF_HUB_CACHE`) set
```
HF_HOME=/huggingface_cache/ huggingface-cli download ibm-granite/granite-3.3-8b-instruct
```
will donwload the model files to
```
/huggingface_cache/hub/models--ibm-granite--granite-3.3-8b-instruct
```
Keeping `HF_HOME=/huggingface_cache/` and running FMS would then re-download the model into
```
/huggingface_cache/models--ibm-granite--granite-3.3-8b-instruct
```