### PR TITLE
[hf_adapter] added GenerationMixin for transformers version compatibility

### DIFF
--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Optional, Tuple, Union
 import torch
 from torch import nn
 from torch.nn.modules.loss import _Loss
-from transformers import PretrainedConfig, PreTrainedModel
+from transformers import PretrainedConfig, PreTrainedModel, GenerationMixin
 from transformers.modeling_outputs import (
     BaseModelOutput,
     BaseModelOutputWithPastAndCrossAttentions,
@@ -916,7 +916,7 @@ class _EncoderArchitectureMixin:
         )
 
 
-class HFDecoderModelArchitecture(HFModelArchitecture):
+class HFDecoderModelArchitecture(HFModelArchitecture, GenerationMixin):
     """
     A specific form of HFModelArchitecture which provides the logic for a decoder model architecture. This class handles
     tasks such as:


### PR DESCRIPTION
Fix for the following:
```
HFDecoderModelArchitecture has generative capabilities, as `prepare_inputs_for_generation` is explicitly defined. However, it doesn't directly inherit from `GenerationMixin`. From 👉v4.50👈 onwards, `PreTrainedModel` will NOT inherit from `GenerationMixin`, and this model will lose the ability to call `generate` and other related functions.
```

```
>>> transformers.__version__
'4.52.0.dev0'
```

```
AttributeError: 'HFAdaptedLLaMAForCausalLM' object has no attribute 'generate'
```