### PR TITLE
Update __init__.py

### DIFF
--- a/fms/__init__.py
+++ b/fms/__init__.py
@@ -1,4 +1,3 @@
-from importlib.metadata import version
+import importlib.metadata
 
-
-__version__ = version("ibm-fms")
+__version__ = importlib.metadata.version("ibm-fms")

--- a/fms/tests/test_version.py
+++ b/fms/tests/test_version.py
@@ -1,0 +1,8 @@
+import fms
+
+
+def test_version_is_defined():
+    assert fms.__version__ is not None
+
+def test_version_attribute_does_not_exist():
+    assert not hasattr(fms, "version")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,5 +4,6 @@ import fms
 def test_version_is_defined():
     assert fms.__version__ is not None
 
+
 def test_version_attribute_does_not_exist():
     assert not hasattr(fms, "version")


### PR DESCRIPTION
The older approach has an unintentional side effect in which the top level library gets a version attribute associated with it.

Co-authored-by: Joe Runde <Joseph.Runde@ibm.com>

```
>>> import fms
>>> fms.version
<function version at 0x102894cc0>
```