### PR TITLE
Devstral small 2505 to fms

### DIFF
--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -224,6 +224,7 @@ def _infer_model_configuration(
         config_params["max_expected_seq_len"] = config.max_position_embeddings
         config_params["kvheads"] = config.num_key_value_heads
         config_params["p_dropout"] = config.attention_dropout
+        config_params["head_dim"] = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
         config_params["norm_eps"] = config.rms_norm_eps
         config_params["rope_base"] = config.rope_theta
         config_params["sliding_window"] = config.sliding_window

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -224,7 +224,10 @@ def _infer_model_configuration(
         config_params["max_expected_seq_len"] = config.max_position_embeddings
         config_params["kvheads"] = config.num_key_value_heads
         config_params["p_dropout"] = config.attention_dropout
-        config_params["head_dim"] = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        config_params["head_dim"] = (
+            getattr(config, "head_dim", None)
+            or config.hidden_size // config.num_attention_heads
+        )
         config_params["norm_eps"] = config.rms_norm_eps
         config_params["rope_base"] = config.rope_theta
         config_params["sliding_window"] = config.sliding_window

--- a/fms/models/mistral.py
+++ b/fms/models/mistral.py
@@ -80,6 +80,7 @@ class MistralConfig(ModelConfig):
     p_dropout: float = 0.0
     activation_fn: str = "swish"
     emb_dim: int = 4096
+    head_dim: int = 128   # getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
     max_expected_seq_len: int = 32768
     kvheads: int = 8
     norm_eps: float = 1e-5
@@ -98,8 +99,11 @@ class MistralBlock(nn.Module):
     def __init__(self, config: MistralConfig, rotary_emb: RotaryEmbedding):
         super(MistralBlock, self).__init__()
         self.config = config
-        emb_kq = self.config.emb_dim // self.config.nheads
-        emb_v = self.config.emb_dim // self.config.nheads
+
+        # emb_kq = self.config.emb_dim // self.config.nheads
+        # emb_v = self.config.emb_dim // self.config.nheads
+        emb_kq = config.head_dim
+        emb_v = config.head_dim
 
         self.ln = LayerNormParameterized(
             self.config.emb_dim,

--- a/fms/models/mistral.py
+++ b/fms/models/mistral.py
@@ -216,7 +216,7 @@ class MistralHeadless(nn.Module):
         )
 
         self.rot_emb = RotaryEmbedding(
-            dim=self.config.emb_dim // self.config.nheads,
+            dim=self.config.head_dim,
             scaling=self.config.rope_scaling,
             max_seq_len=self.config.max_expected_seq_len,
             ratio=self.config.rope_base,

--- a/fms/models/mistral.py
+++ b/fms/models/mistral.py
@@ -80,7 +80,7 @@ class MistralConfig(ModelConfig):
     p_dropout: float = 0.0
     activation_fn: str = "swish"
     emb_dim: int = 4096
-    head_dim: int = 128   # getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+    head_dim: int = 128  # getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
     max_expected_seq_len: int = 32768
     kvheads: int = 8
     norm_eps: float = 1e-5

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -1,9 +1,22 @@
 import os
-from typing import List, Optional, Union
-
+from pathlib import Path
+from typing import List, Optional, Union, Dict, Any
 import torch
+import json
 
 from fms import utils
+
+# git repo : https://github.com/mistralai/mistral-common 
+try:
+    from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+    from mistral_common.protocol.instruct.messages import UserMessage
+    from mistral_common.protocol.instruct.messages import SystemMessage
+    from mistral_common.protocol.instruct.request import ChatCompletionRequest
+    from mistral_common.tokens.tokenizers.base import Tokenized
+    # from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
+    _mistral_available = True
+except ImportError:
+    _mistral_available = False
 
 
 # constants for common tokenizers
@@ -166,6 +179,230 @@ class _HFTokenizer(BaseTokenizer):
         else:
             return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
 
+"""
+MistralAI Tokenizer implementation for foundation-model-stack
+Add this class to fms/utils/tokenizers.py
+"""
+
+class _MistralTokenizer(BaseTokenizer):
+    """
+    MistralAI tokenizer wrapper that follows the same interface as other tokenizers
+    in the foundation model stack.
+    
+    Supports both Tekken (tiktoken-based) and SentencePiece tokenizers:
+    - Tekken: uses tekken.json (newer models like Devstral, Mistral Nemo)
+    - SentencePiece: uses tokenizer.model.v3 (older models like Mistral-7B-v0.3)
+    
+    Requires: pip install mistral-common --upgrade
+    """
+    
+    def __init__(self, model_path: Union[str, Path], **kwargs):
+        if not _mistral_available:
+            raise ImportError(
+                "mistral-common is required for MistralAI tokenizers. "
+                "Please install it with: pip install mistral-common --upgrade"
+            )
+        
+        self.model_path = Path(model_path)
+        self.config = self._load_config()
+        self.system_prompt = self._load_system_prompt()
+        
+        # Try to load the tokenizer from the model path
+        self.tokenizer = self._load_tokenizer()
+        
+        # Get special token IDs from config or use defaults
+        self.bos_token_id = self.config.get("bos_token_id", 1)
+        self.eos_token_id = self.config.get("eos_token_id", 2)
+        self.unk_token_id = self.config.get("unk_token_id", 0)
+        self.pad_token_id = self.config.get("pad_token_id", self.eos_token_id)
+        
+        # Store commonly used special tokens (strings)
+        self.bos_token = "<s>"
+        self.eos_token = "</s>"
+        self.unk_token = "<unk>"
+        self.pad_token = self.eos_token  # Mistral typically uses EOS as pad
+        
+    def _load_config(self) -> Dict[str, Any]:
+        """Load configuration from config.json"""
+        config_path = self.model_path / "config.json"
+        if config_path.exists():
+            with open(config_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        return {}
+    
+    def _load_system_prompt(self) -> str:
+        """Load system promp from model path"""
+        system_prompt = self.model_path / "SYSTEM_PROMPT.txt"
+        if system_prompt.exists():
+            with open(system_prompt, 'r') as f:
+                return f.read()
+        return ""
+
+    def _load_tokenizer(self) -> MistralTokenizer:
+        """Load the appropriate tokenizer based on available files
+        https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/tokens/tokenizers/mistral.py#L227  --> from_file( 
+        https://github.com/mistralai/mistral-common/blob/4b9674a58a29907588afbc477663ea810b0657df/src/mistral_common/tokens/tokenizers/mistral.py#L227
+        """
+        # Check for Tekken tokenizer (newer models)
+        tekken_path = self.model_path / "tekken.json"
+        if tekken_path.exists():
+            try:
+                return MistralTokenizer.from_file(str(tekken_path))
+            except Exception as e:
+                print(f"Warning: Failed to load Tekken tokenizer from {tekken_path}: {e}")
+        
+        # Check for SentencePiece tokenizer v3 (older models)
+        tokenizer_v3_path = self.model_path / "tokenizer.model.v3"
+        if tokenizer_v3_path.exists():
+            try:
+                return MistralTokenizer.from_file(str(tokenizer_v3_path))
+            except Exception as e:
+                print(f"Warning: Failed to load SentencePiece v3 tokenizer from {tokenizer_v3_path}: {e}")
+        
+        # Check for standard SentencePiece tokenizer
+        tokenizer_path = self.model_path / "tokenizer.model"
+        if tokenizer_path.exists():
+            try:
+                return MistralTokenizer.from_file(str(tokenizer_path))
+            except Exception as e:
+                print(f"Warning: Failed to load SentencePiece tokenizer from {tokenizer_path}: {e}")
+        
+        # Fallback: try to load from model name if it's a known model
+        model_name = self.model_path.name
+        try:
+            return MistralTokenizer.from_model(model_name)
+        except Exception as e:
+            raise ValueError(
+                f"Could not load MistralAI tokenizer from {self.model_path}. "
+                f"Expected files: tekken.json, tokenizer.model.v3, or tokenizer.model. "
+                f"Error: {e}"
+            )
+    
+    def tokenize(self, text: str, with_system_prompt: Optional[bool] = False) -> List[str]:
+        """
+        Tokenize text into tokens (strings)
+        
+        Args:
+            text: Input text to tokenize
+            with_system_prompt: Optional[bool] = True -> adds the SYSTEM_PROMPT of the model 
+            
+        Returns:
+            List of string tokens 
+        """
+        if with_system_prompt == True:
+            chat_completion = ChatCompletionRequest(
+                messages=[
+                    SystemMessage(content=self.SYSTEM_PROMPT),
+                    UserMessage(content=text)],)
+        else:
+            chat_completion = ChatCompletionRequest(
+                messages=[UserMessage(content=text)],)
+            
+        self.tokenized = self.tokenizer.encode_chat_completion(chat_completion)
+
+        return self.convert_ids_to_tokens(self.tokenized.tokens)
+
+
+
+
+    def convert_tokenized_to_ids(self, tokenized: Tokenized) -> List[int]:
+        """
+        Convert tokens to token IDs
+        
+        Args:
+            tokenized: Mistral Tokenized object 
+            https://github.com/mistralai/mistral-common/blob/4b9674a58a29907588afbc477663ea810b0657df/src/mistral_common/tokens/tokenizers/base.py#L142
+            
+        Returns:
+            List of token IDs
+        """
+        return tokenized.tokens
+    
+    def convert_tokens_to_ids(self, tokens: List[str]) -> List[int]:
+        """
+        Convert tokens to token IDs
+        
+        Args:
+            tokenized: Mistral Tokenized object 
+            https://github.com/mistralai/mistral-common/blob/4b9674a58a29907588afbc477663ea810b0657df/src/mistral_common/tokens/tokenizers/base.py#L142
+            
+        Returns:
+            List of token IDs
+        """
+        # Quick check if tokens 
+        if tokens == self.convert_ids_to_tokens(self.tokenized.tokens):
+            return self.tokenized.tokens
+        else:
+            raise RuntimeError(f"Misrtral tokenizer error: tokenized list should not be modified")
+
+    
+    def convert_ids_to_tokens(self, ids) -> List[str]:
+        """
+        Convert token IDs to tokens
+        
+        Args:
+            ids: List of token IDs
+            
+        Returns:
+            List of token strings
+        """
+        if isinstance(ids, torch.Tensor):
+            ids = ids.tolist()
+        
+        if isinstance(ids, list) and not all(isinstance(element, int) for element in ids):
+            ids = ids[0]
+
+        return list(map(self.tokenizer.decode, [[i] for i in ids]))
+
+    def convert_tokens_to_string(self, tokens: list[str]):
+        return " ".join(tokens)
+
+
+    def encode(self, text: str, add_special_tokens: bool = False ) -> List[int]:
+        """
+        Encode text to token IDs
+        
+        Args:
+            text: Input text to encode
+            add_special_tokens: Whether to add BOS/EOS tokens
+            
+        Returns:
+            List of token IDs
+        """
+        if (
+            add_special_tokens is True
+            and self.tokenizer.bos_token_id != self.tokenizer.eos_token_id
+        ):
+            return [self.tokenizer.bos_token_id] + self.tokenizer.convert_tokens_to_ids(
+                self.tokenizer.tokenize(text)
+            )
+        else:
+            return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+
+    # def batch_decode(
+    #     self,
+    #     sequences: Union[List[int], List[List[int]]],
+    #     skip_special_tokens: bool = False,
+    # ):
+    #     return self.tokenizer.batch_decode(sequences, skip_special_tokens)
+
+
+    def decode(self, token_ids: List[int]) -> str:
+        """
+        Decode token IDs to text
+        
+        Args:
+            token_ids: List of token IDs to decode
+            
+        Returns:
+            Decoded text string
+        """
+        # return self.tokenizer.decode(token_ids, special_token_policy=SpecialTokenPolicy.IGNORE)
+        return self.tokenizer.decode(token_ids, special_token_policy=0)
+    
+    
+   
+
 
 def get_tokenizer(name: str, style: Optional[str] = None) -> BaseTokenizer:
     """
@@ -199,8 +436,36 @@ def get_tokenizer(name: str, style: Optional[str] = None) -> BaseTokenizer:
         raise RuntimeError(
             f"Could not find tokenizer '{name}' and HuggingFace transformers is not installed"
         )
+    
     if style is None or style == "hf":
         return _HFTokenizer(name)
+
+    if style == "mistralai":
+        return _MistralTokenizer(name)
+
+    # Check for MistralAI tokenizer files (prioritize Tekken)
+    model_path = Path(name)
+    mistral_files = ["tekken.json", "tokenizer.model.v3", "tokenizer.model"]
+    has_mistral_tokenizer = any((model_path / f).exists() for f in mistral_files)
+    if has_mistral_tokenizer:
+        # Check if it's likely a Mistral model
+        model_name = model_path.name.lower()
+        mistral_keywords = ["mistral", "codestral", "devstral", "mixtral", "pixtral"]
+        if any(keyword in model_name for keyword in mistral_keywords):
+            return _MistralTokenizer(name)
+    
+    # Also check config.json for model_type
+    config_path = model_path / "config.json"
+    if config_path.exists():
+        try:
+            with open(config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+            if config.get("architectures")[0] == "MistralForCausalLM":
+                return _MistralTokenizer(name)
+        except Exception:
+            pass
+
+
     if style is None:
         raise RuntimeError(f"Could not find a tokenzier {name}")
     else:

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -6,17 +6,10 @@ import json
 
 from fms import utils
 
-# git repo : https://github.com/mistralai/mistral-common 
-try:
-    from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
-    from mistral_common.protocol.instruct.messages import UserMessage
-    from mistral_common.protocol.instruct.messages import SystemMessage
-    from mistral_common.protocol.instruct.request import ChatCompletionRequest
-    from mistral_common.tokens.tokenizers.base import Tokenized
-    # from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
-    _mistral_available = True
-except ImportError:
-    _mistral_available = False
+# Mistaral
+# git repo : https://github.com/mistralai/mistral-common
+from mistral_common.tokens.tokenizers.tekken import Tekkenizer
+from mistral_common.tokens.tokenizers.tekken import SpecialTokenPolicy
 
 
 # constants for common tokenizers
@@ -154,12 +147,18 @@ class _HFTokenizer(BaseTokenizer):
         return self.tokenizer.batch_decode(sequences, skip_special_tokens)
 
     def tokenize(self, text: str):
+        print(
+            "**** DEPRICATION WARNING ****: Instead of tokenize(), use encode(text: str) -> List[int] methed"
+        )
         return self.tokenizer.tokenize(text)
 
     def convert_ids_to_tokens(self, ids: torch.LongTensor):
         return self.tokenizer.convert_ids_to_tokens(ids)
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
+        print(
+            "**** DEPRICATION WARNING ****: Instead of convert_tokens_to_ids(), use encode(text: str) -> List[int] methed"
+        )
         return self.tokenizer.convert_tokens_to_ids(tokens)
 
     def convert_tokens_to_string(self, tokens: list[str]):
@@ -179,205 +178,177 @@ class _HFTokenizer(BaseTokenizer):
         else:
             return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
 
+
 """
 MistralAI Tokenizer implementation for foundation-model-stack
 Add this class to fms/utils/tokenizers.py
 """
 
-class _MistralTokenizer(BaseTokenizer):
+
+class _TekkenTokenizer(BaseTokenizer):
     """
-    MistralAI tokenizer wrapper that follows the same interface as other tokenizers
+    MistralAI tekken tokenizer wrapper that follows the same interface as other tokenizers
     in the foundation model stack.
-    
-    Supports both Tekken (tiktoken-based) and SentencePiece tokenizers:
-    - Tekken: uses tekken.json (newer models like Devstral, Mistral Nemo)
-    - SentencePiece: uses tokenizer.model.v3 (older models like Mistral-7B-v0.3)
-    
+
+    Supports Tekken (tiktoken-based)
     Requires: pip install mistral-common --upgrade
     """
-    
+
     def __init__(self, model_path: Union[str, Path], **kwargs):
-        if not _mistral_available:
-            raise ImportError(
-                "mistral-common is required for MistralAI tokenizers. "
-                "Please install it with: pip install mistral-common --upgrade"
-            )
-        
         self.model_path = Path(model_path)
         self.config = self._load_config()
         self.system_prompt = self._load_system_prompt()
-        
+
         # Try to load the tokenizer from the model path
         self.tokenizer = self._load_tokenizer()
-        
+
         # Get special token IDs from config or use defaults
         self.bos_token_id = self.config.get("bos_token_id", 1)
         self.eos_token_id = self.config.get("eos_token_id", 2)
         self.unk_token_id = self.config.get("unk_token_id", 0)
         self.pad_token_id = self.config.get("pad_token_id", self.eos_token_id)
-        
+
         # Store commonly used special tokens (strings)
         self.bos_token = "<s>"
         self.eos_token = "</s>"
         self.unk_token = "<unk>"
         self.pad_token = self.eos_token  # Mistral typically uses EOS as pad
-        
+
     def _load_config(self) -> Dict[str, Any]:
         """Load configuration from config.json"""
         config_path = self.model_path / "config.json"
         if config_path.exists():
-            with open(config_path, 'r', encoding='utf-8') as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 return json.load(f)
         return {}
-    
+
     def _load_system_prompt(self) -> str:
         """Load system promp from model path"""
         system_prompt = self.model_path / "SYSTEM_PROMPT.txt"
         if system_prompt.exists():
-            with open(system_prompt, 'r') as f:
+            with open(system_prompt, "r") as f:
                 return f.read()
         return ""
 
-    def _load_tokenizer(self) -> MistralTokenizer:
-        """Load the appropriate tokenizer based on available files
-        https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/tokens/tokenizers/mistral.py#L227  --> from_file( 
-        https://github.com/mistralai/mistral-common/blob/4b9674a58a29907588afbc477663ea810b0657df/src/mistral_common/tokens/tokenizers/mistral.py#L227
+    def _load_tokenizer(self) -> Tekkenizer:
+        """
+        Load the tekken tokenizer
+        https://github.com/mistralai/mistral-common/blob/main/src/mistral_common/tokens/tokenizers/tekken.py
         """
         # Check for Tekken tokenizer (newer models)
         tekken_path = self.model_path / "tekken.json"
         if tekken_path.exists():
             try:
-                return MistralTokenizer.from_file(str(tekken_path))
+                return Tekkenizer.from_file(str(tekken_path))
             except Exception as e:
-                print(f"Warning: Failed to load Tekken tokenizer from {tekken_path}: {e}")
-        
-        # Check for SentencePiece tokenizer v3 (older models)
-        tokenizer_v3_path = self.model_path / "tokenizer.model.v3"
-        if tokenizer_v3_path.exists():
-            try:
-                return MistralTokenizer.from_file(str(tokenizer_v3_path))
-            except Exception as e:
-                print(f"Warning: Failed to load SentencePiece v3 tokenizer from {tokenizer_v3_path}: {e}")
-        
-        # Check for standard SentencePiece tokenizer
-        tokenizer_path = self.model_path / "tokenizer.model"
-        if tokenizer_path.exists():
-            try:
-                return MistralTokenizer.from_file(str(tokenizer_path))
-            except Exception as e:
-                print(f"Warning: Failed to load SentencePiece tokenizer from {tokenizer_path}: {e}")
-        
-        # Fallback: try to load from model name if it's a known model
-        model_name = self.model_path.name
-        try:
-            return MistralTokenizer.from_model(model_name)
-        except Exception as e:
-            raise ValueError(
-                f"Could not load MistralAI tokenizer from {self.model_path}. "
-                f"Expected files: tekken.json, tokenizer.model.v3, or tokenizer.model. "
-                f"Error: {e}"
+                print(f"Error: Failed to load Tekken tokenizer from {tekken_path}: {e}")
+                raise RuntimeError(
+                    f"Tekkenizer failed to load tekken.json at model_path {self.model_path}"
+                )
+        else:
+            raise RuntimeError(
+                f"Tekkenizer Error: Could not find the tekken.json at model_path {self.model_path}"
             )
-    
-    def tokenize(self, text: str, with_system_prompt: Optional[bool] = False) -> List[str]:
+
+    def encode(
+        self, text: str, add_special_tokens: Optional[bool] = False
+    ) -> List[int]:
+        """Encode a string into a list of token ids.
+
+        Args:
+            text (str): input text string to be tokenized and converted to ids
+            add_special_tokens (bool, optional): prefix bos token to the input text
+
+        Returns:
+            List[int]: token ids of tokenized text string
+        """
+        return self.tokenizer.encode(text, bos=add_special_tokens, eos=False)
+
+    def decode(
+        self,
+        token_ids: List[int],
+        special_token_policy: Optional[SpecialTokenPolicy] = None,
+    ) -> str:
+        """Decode a list of token ids into a string.
+
+        Args:
+            token_ids (List[int]): The list of token ids to decode.
+            special_token_policy: The policy for handling special tokens.
+                Use the tokenizer's [attribute][mistral_common.tokens.tokenizers.tekken.Tekkenizer.special_token_policy]
+                if `None`. Passing `None` is deprecated and will be changed
+                to `SpecialTokenPolicy.IGNORE` in `mistral_common=1.7.0`.
+
+        Returns:
+            str: Decoded text string
+        """
+        return self.tokenizer.decode(token_ids, special_token_policy)
+
+    def tokenize(self, text: str) -> List[str]:
         """
         Tokenize text into tokens (strings)
-        
+
         Args:
             text: Input text to tokenize
-            with_system_prompt: Optional[bool] = True -> adds the SYSTEM_PROMPT of the model 
-            
         Returns:
-            List of string tokens 
+            List of string tokens
         """
-        if with_system_prompt == True:
-            chat_completion = ChatCompletionRequest(
-                messages=[
-                    SystemMessage(content=self.SYSTEM_PROMPT),
-                    UserMessage(content=text)],)
-        else:
-            chat_completion = ChatCompletionRequest(
-                messages=[UserMessage(content=text)],)
-            
-        self.tokenized = self.tokenizer.encode_chat_completion(chat_completion)
+        print(
+            "**** DEPRICATION WARNING ****: Instead of tokenize(), use encode(text: str) -> List[int] methed"
+        )
+        self.ids = self.encode(text)
+        return list(map(self.tokenizer.decode, [[id] for id in self.ids]))
 
-        return self.convert_ids_to_tokens(self.tokenized.tokens)
-
-
-
-
-    def convert_tokenized_to_ids(self, tokenized: Tokenized) -> List[int]:
+    def convert_tokens_to_ids(self, tokens: Union[str, list[str]]) -> List[int]:
         """
         Convert tokens to token IDs
-        
+
         Args:
-            tokenized: Mistral Tokenized object 
-            https://github.com/mistralai/mistral-common/blob/4b9674a58a29907588afbc477663ea810b0657df/src/mistral_common/tokens/tokenizers/base.py#L142
-            
+            tokens:
+
         Returns:
             List of token IDs
         """
-        return tokenized.tokens
-    
-    def convert_tokens_to_ids(self, tokens: List[str]) -> List[int]:
-        """
-        Convert tokens to token IDs
-        
-        Args:
-            tokenized: Mistral Tokenized object 
-            https://github.com/mistralai/mistral-common/blob/4b9674a58a29907588afbc477663ea810b0657df/src/mistral_common/tokens/tokenizers/base.py#L142
-            
-        Returns:
-            List of token IDs
-        """
-        # Quick check if tokens 
-        if tokens == self.convert_ids_to_tokens(self.tokenized.tokens):
-            return self.tokenized.tokens
-        else:
-            raise RuntimeError(f"Misrtral tokenizer error: tokenized list should not be modified")
+        print(
+            "**** DEPRICATION WARNING ****: Instead of convert_tokens_to_ids(), use encode(text: str) -> List[int] methed"
+        )
+        try:
+            if len(self.ids) == len(tokens):
+                return self.ids
+        except Exception as e:
+            raise RuntimeError(
+                f"Misrtral tokenizer error: convert_tokens_to_ids() must be used in tandum with tokenize() Error: {type(e).__name__} occurred: {e}"
+            )
 
-    
     def convert_ids_to_tokens(self, ids) -> List[str]:
         """
         Convert token IDs to tokens
-        
+
         Args:
             ids: List of token IDs
-            
+
         Returns:
             List of token strings
         """
         if isinstance(ids, torch.Tensor):
             ids = ids.tolist()
-        
-        if isinstance(ids, list) and not all(isinstance(element, int) for element in ids):
+
+        if isinstance(ids, list) and not all(
+            isinstance(element, int) for element in ids
+        ):
             ids = ids[0]
 
         return list(map(self.tokenizer.decode, [[i] for i in ids]))
 
-    def convert_tokens_to_string(self, tokens: list[str]):
-        return " ".join(tokens)
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        """Conver list of string tokens
 
-
-    def encode(self, text: str, add_special_tokens: bool = False ) -> List[int]:
-        """
-        Encode text to token IDs
-        
         Args:
-            text: Input text to encode
-            add_special_tokens: Whether to add BOS/EOS tokens
-            
+            tokens (list[str]): _description_
+
         Returns:
-            List of token IDs
+            str: _description_
         """
-        if (
-            add_special_tokens is True
-            and self.tokenizer.bos_token_id != self.tokenizer.eos_token_id
-        ):
-            return [self.tokenizer.bos_token_id] + self.tokenizer.convert_tokens_to_ids(
-                self.tokenizer.tokenize(text)
-            )
-        else:
-            return self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(text))
+        return "".join(tokens)
 
     # def batch_decode(
     #     self,
@@ -385,23 +356,6 @@ class _MistralTokenizer(BaseTokenizer):
     #     skip_special_tokens: bool = False,
     # ):
     #     return self.tokenizer.batch_decode(sequences, skip_special_tokens)
-
-
-    def decode(self, token_ids: List[int]) -> str:
-        """
-        Decode token IDs to text
-        
-        Args:
-            token_ids: List of token IDs to decode
-            
-        Returns:
-            Decoded text string
-        """
-        # return self.tokenizer.decode(token_ids, special_token_policy=SpecialTokenPolicy.IGNORE)
-        return self.tokenizer.decode(token_ids, special_token_policy=0)
-    
-    
-   
 
 
 def get_tokenizer(name: str, style: Optional[str] = None) -> BaseTokenizer:
@@ -436,35 +390,13 @@ def get_tokenizer(name: str, style: Optional[str] = None) -> BaseTokenizer:
         raise RuntimeError(
             f"Could not find tokenizer '{name}' and HuggingFace transformers is not installed"
         )
-    
+
+    model_path = Path(name)
+    if style == "tekken" or (model_path / "tekken.json").exists():
+        return _TekkenTokenizer(name)
+
     if style is None or style == "hf":
         return _HFTokenizer(name)
-
-    if style == "mistralai":
-        return _MistralTokenizer(name)
-
-    # Check for MistralAI tokenizer files (prioritize Tekken)
-    model_path = Path(name)
-    mistral_files = ["tekken.json", "tokenizer.model.v3", "tokenizer.model"]
-    has_mistral_tokenizer = any((model_path / f).exists() for f in mistral_files)
-    if has_mistral_tokenizer:
-        # Check if it's likely a Mistral model
-        model_name = model_path.name.lower()
-        mistral_keywords = ["mistral", "codestral", "devstral", "mixtral", "pixtral"]
-        if any(keyword in model_name for keyword in mistral_keywords):
-            return _MistralTokenizer(name)
-    
-    # Also check config.json for model_type
-    config_path = model_path / "config.json"
-    if config_path.exists():
-        try:
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config = json.load(f)
-            if config.get("architectures")[0] == "MistralForCausalLM":
-                return _MistralTokenizer(name)
-        except Exception:
-            pass
-
 
     if style is None:
         raise RuntimeError(f"Could not find a tokenzier {name}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # Useful for dev/test jobs caches
 # Must be kept in sync with setup.py
 torch >= 2.5.1 # This is what is installed in CI today
+mistral-common 


### PR DESCRIPTION
This PR added support for the `mistralai/Devstral-Small-2505` model. 

- In the mistral implementation, `fms/models/mistral.py` and `fms/models/hf/utils.py` added a config parameter `head_dim`
- The Tekken tokenizer class is added to `fms/utils/tokenizers.py` to support the required tokenizer 
- `mistral-common` is added to the `requirements.txt`

Closes #423 

