### PR TITLE
Tekken tokenizer class added to support the Mistral models

### DIFF
--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -292,34 +292,30 @@ class _TekkenTokenizer(BaseTokenizer):
         """
         return self.tokenizer.encode(text, bos=add_special_tokens, eos=False)
 
-    def decode(
-        self,
-        token_ids: List[int],
-        stp=0,  # SpecialTokenPolicy = SpecialTokenPolicy.IGNORE,
-    ) -> str:
-        """Decode a list of token ids into a string.
+    def decode(self, ids: List[int], skip_special_tokens: Optional[bool] = True) -> str:
+        """Decode the given list of ids to a string sequence
 
         Args:
-            token_ids (List[int]): The list of token ids to decode.
-            special_token_policy: The policy for handling special tokens.
-                Use the tokenizer's [attribute][mistral_common.tokens.tokenizers.tekken.Tekkenizer.special_token_policy]
-                if `None`. Passing `None` is deprecated and will be changed
-                to `SpecialTokenPolicy.IGNORE` in `mistral_common=1.7.0`.
+            ids: List[unsigned int]:
+                A list of ids to be decoded
 
-                SpecialTokenPolicy
-                IGNORE = 0
-                KEEP = 1
-                RAISE = 2
+            skip_special_tokens: (`optional`) boolean:
+                Whether to remove all the special tokens from the output string
+                Mistral: SpecialTokenPolicy
+                IGNORE = 0 --> skip_special_tokens = True
+                KEEP = 1  --> skip_special_tokens = False
 
         Returns:
-            str: Decoded text string
+            The decoded string
         """
         from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy  # type: ignore
 
-        if stp == 0:
+        if skip_special_tokens:
             stp = SpecialTokenPolicy.IGNORE  # type: ignore
+        else:
+            stp = SpecialTokenPolicy.KEEP  # type: ignore
 
-        return self.tokenizer.decode(token_ids, stp)
+        return self.tokenizer.decode(ids, stp)
 
     def tokenize(self, text: str) -> List[str]:
         """


### PR DESCRIPTION
This PR added Tekken tokenizer class support for the `mistralai/Devstral-Small-2505` model.
This is split from https://github.com/foundation-model-stack/foundation-model-stack/pull/427 to take care of the comment:
https://github.com/foundation-model-stack/foundation-model-stack/pull/427#pullrequestreview-2951118727 

> We might want to split up the tokenizer and model implementation into 2 separate PRs

Closes #433 

# Minimal Test
```python
from fms.utils import tokenizers
MODEL_PATH="/mnt/aiu-models-en-shared/models/mistralai/Devstral-Small-2505"
tokenizer = tokenizers.get_tokenizer(MODEL_PATH)
```

# Note: 
It is normal to get the following warning message. 
```
mistral_common/tokens/tokenizers/tekken.py:240: FutureWarning: Special tokens not found in /mnt/aiu-models-en-shared/models/mistralai/Devstral-Small-2505/tekken.json and default to ({'rank': 0, 'token_str': <SpecialTokens.unk: '<unk>'>, 'is_control': True}, {'rank': 1, 'token_str': <SpecialTokens.bos: '<s>'>, 'is_control': True}, {'rank': 2, 'token_str': <SpecialTokens.eos: '</s>'>, 'is_control': True}, {'rank': 3, 'token_str': <SpecialTokens.begin_inst: '[INST]'>, 'is_control': True}, {'rank': 4, 'token_str': <SpecialTokens.end_inst: '[/INST]'>, 'is_control': True}, {'rank': 5, 'token_str': <SpecialTokens.begin_tools: '[AVAILABLE_TOOLS]'>, 'is_control': True}, {'rank': 6, 'token_str': <SpecialTokens.end_tools: '[/AVAILABLE_TOOLS]'>, 'is_control': True}, {'rank': 7, 'token_str': <SpecialTokens.begin_tool_results: '[TOOL_RESULTS]'>, 'is_control': True}, {'rank': 8, 'token_str': <SpecialTokens.end_tool_results: '[/TOOL_RESULTS]'>, 'is_control': True}, {'rank': 9, 'token_str': <SpecialTokens.tool_calls: '[TOOL_CALLS]'>, 'is_control': True}, {'rank': 10, 'token_str': <SpecialTokens.img: '[IMG]'>, 'is_control': True}, {'rank': 11, 'token_str': <SpecialTokens.pad: '<pad>'>, 'is_control': True}, {'rank': 12, 'token_str': <SpecialTokens.img_break: '[IMG_BREAK]'>, 'is_control': True}, {'rank': 13, 'token_str': <SpecialTokens.img_end: '[IMG_END]'>, 'is_control': True}, {'rank': 14, 'token_str': <SpecialTokens.prefix: '[PREFIX]'>, 'is_control': True}, {'rank': 15, 'token_str': <SpecialTokens.middle: '[MIDDLE]'>, 'is_control': True}, {'rank': 16, 'token_str': <SpecialTokens.suffix: '[SUFFIX]'>, 'is_control': True}, {'rank': 17, 'token_str': <SpecialTokens.begin_system: '[SYSTEM_PROMPT]'>, 'is_control': True}, {'rank': 18, 'token_str': <SpecialTokens.end_system: '[/SYSTEM_PROMPT]'>, 'is_control': True}, {'rank': 19, 'token_str': <SpecialTokens.begin_tool_content: '[TOOL_CONTENT]'>, 'is_control': True}). This behavior will be deprecated going forward. Please update your tokenizer file and include all special tokens you need.
  warnings.warn(
  ```