### PR TITLE
[typing_extensions] for backwards compatibility

### DIFF
--- a/fms/models/bamba.py
+++ b/fms/models/bamba.py
@@ -2,7 +2,8 @@ import dataclasses
 import logging
 import math
 import re
-from typing import Any, List, Mapping, Optional, Tuple, Unpack
+from typing import Any, List, Mapping, Optional, Tuple
+from typing_extensions import Unpack
 
 import torch
 import torch.nn as nn

--- a/fms/models/gpt_bigcode.py
+++ b/fms/models/gpt_bigcode.py
@@ -1,6 +1,7 @@
 import functools
 from dataclasses import dataclass
-from typing import Any, List, Mapping, Optional, Tuple, Unpack
+from typing import Any, List, Mapping, Optional, Tuple
+from typing_extensions import Unpack
 
 import torch
 import torch.nn as nn

--- a/fms/models/granite.py
+++ b/fms/models/granite.py
@@ -2,7 +2,8 @@ import logging
 import math
 import re
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional, Tuple, Unpack
+from typing import Any, Mapping, Optional, Tuple
+from typing_extensions import Unpack
 
 import torch
 import torch.nn as nn

--- a/fms/models/hf/llama/modeling_llama_hf.py
+++ b/fms/models/hf/llama/modeling_llama_hf.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, Unpack
+from typing import Optional, Tuple
+from typing_extensions import Unpack
 
 from fms.modules.attention import SDPAAttentionKwargs
 import torch

--- a/fms/models/hf/mixtral/modeling_mixtral_hf.py
+++ b/fms/models/hf/mixtral/modeling_mixtral_hf.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, Unpack
+from typing import Optional, Tuple
+from typing_extensions import Unpack
 
 from fms.modules.attention import SDPAAttentionKwargs
 import torch

--- a/fms/models/llama.py
+++ b/fms/models/llama.py
@@ -1,7 +1,8 @@
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Optional, Tuple, Unpack
+from typing import Any, Mapping, Optional, Tuple
+from typing_extensions import Unpack
 
 import torch
 import torch.nn as nn

--- a/fms/models/mistral.py
+++ b/fms/models/mistral.py
@@ -2,7 +2,8 @@ import logging
 import math
 import re
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Optional, Tuple, Unpack
+from typing import Any, Mapping, Optional, Tuple
+from typing_extensions import Unpack
 
 import torch
 import torch.nn as nn
@@ -61,7 +62,7 @@ logger = logging.getLogger(__name__)
   "num_key_value_heads": 8,
   "rms_norm_eps": 1e-05,
   "rope_theta": 1000000.0,
-  "sliding_window": null,     X 
+  "sliding_window": null,     X
   "tie_word_embeddings": false,
   "torch_dtype": "bfloat16",
   "transformers_version": "4.42.0.dev0",

--- a/fms/models/mixtral.py
+++ b/fms/models/mixtral.py
@@ -1,7 +1,8 @@
 import math
 import re
 from dataclasses import dataclass
-from typing import Any, Mapping, MutableMapping, Optional, Tuple, Unpack
+from typing import Any, Mapping, MutableMapping, Optional, Tuple
+from typing_extensions import Unpack
 
 import torch
 import torch.nn as nn

--- a/fms/modules/attention.py
+++ b/fms/modules/attention.py
@@ -6,12 +6,11 @@ from typing import (
     Concatenate,
     List,
     Mapping,
-    NotRequired,
     Optional,
     Tuple,
     TypedDict,
-    Unpack,
 )
+from typing_extensions import NotRequired, Unpack
 
 import torch
 import torch.distributed


### PR DESCRIPTION
Unpack and NotRequired don't exist prior to python 3.11, this allows for compatibility.