### PR TITLE
Add BERT QA support

### DIFF
--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -205,6 +205,16 @@ def _infer_model_configuration(
         config_params["p_dropout"] = config.hidden_dropout_prob
         config_params["norm_eps"] = config.layer_norm_eps
         config_params["activation_fn"] = config.hidden_act
+    elif architecture == "BertForQuestionAnswering":
+        inner_dim = config.intermediate_size
+        architecture = "bert_question_answering"
+        config_params["emb_dim"] = config.hidden_size
+        config_params["pad_id"] = config.pad_token_id
+        config_params["max_pos"] = config.max_position_embeddings  # differs from roberta
+        config_params["p_dropout"] = config.hidden_dropout_prob
+        config_params["norm_eps"] = config.layer_norm_eps
+        config_params["activation_fn"] = config.hidden_act
+        config_params["type_vocab_size"] = config.type_vocab_size  # differs from roberta
     elif architecture == "GraniteForCausalLM":
         inner_dim = config.intermediate_size
         architecture = "granite"


### PR DESCRIPTION
This PR adds support for BERT Question Answering (one task only).

The architecture is named `bert_question_answering`. This selection will build an FMS `RoBERTaQuestionAnswering` model using BERT config. The models appear to be almost identical, except for max position embeddings and vocab type size, which have been adjusted in the config.

PR includes:
- add parameters to initialize config file when using `hf_pretrained`
- name adapter from HF BERT QA to FMS BERT QA (lots of overlap with RoBERTa QA, the adapters could be combined)

Draft PR for now, because accuracy of both FP16 and FP8 models is not on par with expectations (F1 ~ 55% instead of >70%).

Unit tests are passing.