### PR TITLE
Add prefil decode in expectations

### DIFF
--- a/fms/testing/_internal/model_test_suite.py
+++ b/fms/testing/_internal/model_test_suite.py
@@ -217,17 +217,6 @@ class ModelCompileTestSuite(ModelFixtureMixin):
         """
         pass
 
-    @property
-    def _get_signature_optional_params(self) -> Optional[dict[str, torch.Tensor]]:
-        """the value to pass into optional_params in get_signature function for this model
-
-        Returns
-        -------
-        Optional[dict[str, torch.Tensor]]
-            the dictionary of optional params to pass to the model
-        """
-        return {}
-
     @pytest.mark.skipif(
         platform.system() != "Linux",
         reason=f"pytorch compile is more stable on Linux, skipping as current platform is {platform.platform()}",
@@ -382,9 +371,6 @@ class ModelConsistencyTestSuite(ModelFixtureMixin, SignatureFixtureMixin):
     def test_model_output(self, model, signature, model_id, capture_expectation):
         """test consistency of model output with signature"""
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        model = model.to(device)
-
         # Test standard forward pass signature
         actual = get_signature(
             model,
@@ -392,7 +378,7 @@ class ModelConsistencyTestSuite(ModelFixtureMixin, SignatureFixtureMixin):
             params=self._get_signature_params,
             optional_params=self._get_signature_optional_params,
             logits_getter_fn=self._get_signature_logits_getter_fn,
-            device=device,
+            device="cuda" if torch.cuda.is_available() else "cpu",
         )
 
         # Test generation signature for applicable models


### PR DESCRIPTION
Enhanced test_model_output to include generation testing (1 prefill + 1 decode) alongside forward pass testing for causal language models.

Changes:

_supports_generation(): Detects causal LMs by checking for lm_head/head/shared attributes, excludes vision/encoder-only models
(Causal models (LLaMA, GPT-BigCode, Granite, Mistral) now test both inference and generation
Non-generative models (RoBERTa, SigLIP) unchanged - forward pass only)

_get_generation_signature(): Performs 1 token generation using generate() with greedy sampling, returns token sum as signature
Enhanced test_model_output(): Combines forward pass + generation signatures for applicable models

Expectation files now contain combined signatures: [forward_values..., generation_value]


Usage:
Existing expectation files need regeneration: `python -m pytest tests/models/ -v -s --capture_expectation`

Test  LLaMA2
`python -m pytest tests/models/test_llama.py::TestLlama2::test_model_output -v-s ` 
`python -m pytest tests/models/test_llama.py::TestLlama2::test_model_unfused -v -s`

Run all model tests = `python -m pytest tests/models/ -v -s`

P.S - still debugging 