### PR TITLE
fix: n_groups expansion

### DIFF
--- a/fms/modules/ssm.py
+++ b/fms/modules/ssm.py
@@ -382,8 +382,12 @@ class SSM(nn.Module):
             ).float()
             B = B.reshape(batch_size, seq_len, -1, self.ssm_state_size).float()
             C = C.reshape(batch_size, seq_len, -1, self.ssm_state_size).float()
-            B = B.repeat(1, 1, self.nheads // self.n_groups, 1)
-            C = C.repeat(1, 1, self.nheads // self.n_groups, 1)
+            B = B.repeat_interleave(
+                self.nheads // self.n_groups, dim=2, output_size=self.nheads
+            )
+            C = C.repeat_interleave(
+                self.nheads // self.n_groups, dim=2, output_size=self.nheads
+            )
             pad_size = (self.chunk_size - seq_len % self.chunk_size) % self.chunk_size
 
             D_residual = self.D[..., None] * pad_tensor_by_size(hidden_states, pad_size)


### PR DESCRIPTION
Fixes the logic around tensor expansion when `n_groups > 1` following the analogous `transformers` [PR.](https://github.com/huggingface/transformers/pull/37533)