### PR TITLE
Granite 2b & 3b expand K Q V and Dense to head dim 128 to compile for AIU

### DIFF
--- a/fms/models/granite.py
+++ b/fms/models/granite.py
@@ -59,7 +59,8 @@ class GraniteBlock(nn.Module):
     def __init__(self, config: GraniteConfig, rotary_emb: RotaryEmbedding):
         super(GraniteBlock, self).__init__()
         self.config = config
-        emb_kq = self.config.emb_dim // self.config.nheads
+        # *** ALERT *** Granite 2b hack for AIU Compiler 
+        emb_kq = 128 # self.config.emb_dim // self.config.nheads
         emb_v = self.config.emb_dim // self.config.nheads
 
         self.ln = LayerNormParameterized(

--- a/fms/models/granite.py
+++ b/fms/models/granite.py
@@ -331,10 +331,11 @@ class Granite(nn.Module):
         else:
             self.config = GraniteConfig()
         self.config = self.config.updated(**kwargs)
-        
-        if self.config.emb_dim < 4096:
+
+        # *** ALERT *** Granite 2b hack for AIU Compiler 
+        if (self.config.emb_dim // self.config.nheads) < 128:
             self.config.orig_emb_dim = self.config.emb_dim
-            self.config.emb_dim = 4096
+            self.config.emb_dim = self.config.emb_dim * (128 // (self.config.emb_dim // self.config.nheads))
 
 
         self.distributed_strategy = distributed_strategy

--- a/fms/models/granite.py
+++ b/fms/models/granite.py
@@ -60,8 +60,9 @@ class GraniteBlock(nn.Module):
         super(GraniteBlock, self).__init__()
         self.config = config
         # *** ALERT *** Granite 2b hack for AIU Compiler 
-        emb_kq = 128 # self.config.emb_dim // self.config.nheads
-        emb_v = self.config.emb_dim // self.config.nheads
+        emb_dim = self.config.emb_dim * 2
+        emb_kq = emb_dim // self.config.nheads
+        emb_v = emb_dim // self.config.nheads
 
         self.ln = LayerNormParameterized(
             self.config.emb_dim,

--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -232,9 +232,7 @@ class RotaryEmbedding(PositionEncoder):
         """
         super(RotaryEmbedding, self).__init__()
         self.partial_rope = partial_rope
-        # *** ALERT *** Granite 2b hack for AIU Compiler 
-        # # self.dim = int(partial_rope * dim)
-        self.dim = 128
+        self.dim = int(partial_rope * dim)
         own_scaling = copy.deepcopy(scaling)
         if "rope_type" not in own_scaling:
             own_scaling["rope_type"] = "regular"

--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -232,7 +232,9 @@ class RotaryEmbedding(PositionEncoder):
         """
         super(RotaryEmbedding, self).__init__()
         self.partial_rope = partial_rope
-        self.dim = int(partial_rope * dim)
+        # *** ALERT *** Granite 2b hack for AIU Compiler 
+        # # self.dim = int(partial_rope * dim)
+        self.dim = 128
         own_scaling = copy.deepcopy(scaling)
         if "rope_type" not in own_scaling:
             own_scaling["rope_type"] = "regular"

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -650,6 +650,9 @@ def _load_partial_state_dict(
                     )
                     setattr(target_module, key_steps[-1], param)
                     param = getattr(target_module, key_steps[-1])
+                # *** ALERT *** Granite 2b hack for AIU Compiler 
+                if param.size() != tensor_value.size():
+                    tensor_value = torch.stack((tensor_value, torch.zeros_like(tensor_value)), dim=1).view(*(param.size()))
                 param.copy_(tensor_value, non_blocking=True)
 
             elif tp_module is not None and tp_module not in seen_tp_modules:

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -652,11 +652,7 @@ def _load_partial_state_dict(
                     param = getattr(target_module, key_steps[-1])
                 # *** ALERT *** Granite 2b hack for AIU Compiler 
                 if param.size() != tensor_value.size():
-                    print(f"**** {key}")
-                    print(f"**** Expanding weights of {key_steps[-2]}  from size {tensor_value.size()} => to match param size {param.size()}")
-                    if tensor_value.ndim != param.ndim:
-                        raise ValueError("Tensors must have the same number of dimensions.")
-
+                    print(f"* Expanding weights of {(".".join(key_steps[1:-1])):30.30} {str(list(tensor_value.size())):12.12} => {list(param.size())}")
                     slices = []
                     for dim in range(tensor_value.ndim):
                         expand_factor = param.shape[dim] // tensor_value.shape[dim]
@@ -665,13 +661,10 @@ def _load_partial_state_dict(
                             slices.append(slice(0, None, expand_factor))
                         else:
                             slices.append(slice(None))
-                    # print(slices)
-                    # Assign the original tensor to the correct interleaved positions
+                    # Assign the original weights tensor to the interleaved positions
                     expanded_tensor = torch.zeros_like(param)
                     expanded_tensor[tuple(slices)] = tensor_value
                     tensor_value = expanded_tensor
-                    # tensor_value = torch.stack((tensor_value, torch.zeros_like(tensor_value)), dim=1).view(*(param.size()))
-                    # print("**** AFTER matching ****", tensor_value.size(), " => " , param.size())
                     
                 param.copy_(tensor_value, non_blocking=True)
 


### PR DESCRIPTION
The head-dim sizes of the Granite 2b and 3b models are not supported by the AIU compiler. We observed that AIU compiler compiled Granite 8b, which has head-dim = 128. This PR implements a way to expand the sizes of K, Q, V, and Dense of attention layers, to make the head-dim = 128. For that, I did the following modification 

1. **graninte.py** -- Conditionally expand the sizes of K, Q, V, and Dense of attention layers, this will leave the 8b model intact.
```py
        if (self.config.emb_dim // self.config.nheads) < 128:
            self.config.orig_emb_dim = self.config.emb_dim
            self.config.emb_dim = self.config.emb_dim * (128 // (self.config.emb_dim // self.config.nheads))
```
We use the expanded emb_dim for the KQ, V, and RoPE. The rest of the model uses the original `orig_emb_dim`.

2. **serialization.py** -- The weights of the K, Q, V, and Dense are expanded by interleaving zero columns. This implementation does not affect other models.
```py
                 if param.size() != tensor_value.size():
                    slices = []
                    for dim in range(tensor_value.ndim):
                        expand_factor = param.shape[dim] // tensor_value.shape[dim]
                        if expand_factor > 1:
                            slices.append(slice(0, None, expand_factor))
                        else:
                            slices.append(slice(None))
                    expanded_tensor = torch.zeros_like(param)
                    expanded_tensor[tuple(slices)] = tensor_value
                    tensor_value = expanded_tensor
``` 
