### PR TITLE
updated transformers to 4.55.4 and fixed bug where fms expected cache to be None

### DIFF
--- a/fms/models/hf/modeling_hf_adapter.py
+++ b/fms/models/hf/modeling_hf_adapter.py
@@ -533,7 +533,9 @@ class HFDecoder(_HFBase):
         *args,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        is_cache_used_and_filled = use_cache and past_key_values is not None
+        is_cache_used_and_filled = use_cache and (
+            past_key_values is not None and len(past_key_values) != 0
+        )
         return HFDecoderModelArchitecture._produce_decoder_attention_mask_from_hf(
             attention_mask, is_cache_used_and_filled
         )
@@ -1673,7 +1675,9 @@ class HFEncoderDecoderModelArchitecture(
                 )
 
         # compute the decoder attention masks (3d and 2d)
-        is_cache_used_and_filled = use_cache and past_key_values is not None
+        is_cache_used_and_filled = use_cache and (
+            past_key_values is not None and len(past_key_values) != 0
+        )
         (
             decoder_attention_mask,
             hf_dec_attention_mask,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
 "mypy-extensions==1.0.0",
 "pytest==8.3.4",
 "sentencepiece==0.2.0",
-"transformers==4.48.3",
+"transformers==4.55.4",
 "pyarrow-stubs==17.16",
 "types-requests==2.32.0.20241016",
 "lm_eval==0.4.7",


### PR DESCRIPTION
This PR updates transformers and fixes a bug where fms expects past_key_values to be None, but new version of transformers is sending in DynamicCache