### PR TITLE
Fix error message for input id types

### DIFF
--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -239,7 +239,7 @@ def generate(
         if not is_batch:
             input_ids = input_ids.unsqueeze(0)
     else:
-        raise TypeError("input_ids must be one of Tensor or List")
+        raise TypeError("input_ids must be a tensor")
 
     eos_found = torch.zeros(
         input_ids.shape[0], dtype=torch.bool, device=input_ids.device


### PR DESCRIPTION
Changes the error message when validating input ID types to match the type check and docstring.

@JRosenkranz could you take a look when you have a moment?