### PR TITLE
`ModelConfig.updated(**kwargs)` method to support mulimodel config

### DIFF
--- a/fms/utils/config.py
+++ b/fms/utils/config.py
@@ -60,8 +60,9 @@ class ModelConfig:
             if hasattr(copied_config, k):
                 # For multi-model hierarchical configs, ModelConfig are nested
                 # i.e. ModelConfig may contain sub ModelConfig(s).
-                # A dict passed passed as kwarg can update parameter(s) in the nested hierarchy
+                # A dict passed as kwarg can update parameter(s) in the nested hierarchy
                 # for this the key must be an existing sub config of ModelConfig and the value must be a dict
+                # Since we are recursively calling `updated` method it is possible to have sub-configs in sub-configs
                 if isinstance(getattr(copied_config, k), ModelConfig) and isinstance(
                     v, dict
                 ):


### PR DESCRIPTION
This fixes the issue https://github.com/foundation-model-stack/foundation-model-stack/issues/482

Example: Granite Vision model 
```python

config_dict = {}
config_dict['head_dim'] = 128

model = get_model(
    args.architecture,
    args.variant,
    model_path=args.model_path,
    device_type="cpu" if is_aiu_backend else args.device_type,
    data_type=default_dtype,
    source=args.model_source,
    distributed_strategy=distr_param,
    group=dist.group.WORLD,
    linear_config=linear_config,
    fused_weights=fused_weights,
    override_hf_pretrained_config=True,  # <= This is needed only for hf_pretrained
    text_config=config_dict              # <= text_config, which is text_config=GraniteConfig(....) 
)
```

