### PR TITLE
expansion adaper to allow language model for llava-next

### DIFF
--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -588,6 +588,13 @@ serialization.register_adapter_step(
     _architecture_name, "hf_to_fms_names", _hf_to_fms_names
 )
 
+
+serialization.register_adapter_step(
+    _architecture_name,
+    "weight_expansion_for_mismatched_head_dim",
+    serialization._weight_expansion_for_mismatched_head_dim,  # type: ignore[arg-type]
+)
+
 serialization.register_adapter_step(
     _architecture_name, "hf_to_fms_rope", _hf_to_fms_rope
 )


### PR DESCRIPTION
This PR fixes the issue https://github.com/foundation-model-stack/foundation-model-stack/issues/485 
For multi-model (like Granite Vision model), the expansion adapter now supports expansion applied to the language model component. 

### Example call:
```python 

serialization.extend_adapter("llava_next", "hf", ["weight_expansion_for_mismatched_head_dim"])

config_dict = {}
config_dict['head_dim'] = 128

model = get_model(
    args.architecture,
    args.variant,
    model_path=args.model_path,
    device_type="cpu" if is_aiu_backend else args.device_type,
    data_type=default_dtype,
    source=args.model_source,
    distributed_strategy=distr_param,
    group=dist.group.WORLD,
    linear_config=linear_config,
    fused_weights=fused_weights,
    override_hf_pretrained_config=True,
    text_config=config_dict
)
```