### PR TITLE
Granite-vision / llava_next fix for AIU: explicit call embedding layer

### DIFF
--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -603,5 +603,5 @@ serialization.register_adapter_step(
 serialization.register_adapter(
     _architecture_name,
     "hf",
-    ["hf_to_fms_names", "hf_to_fms_rope", "weight_expansion_for_mismatched_head_dim", "weight_fusion"],
+    ["hf_to_fms_names", "hf_to_fms_rope", "weight_fusion"],
 )


### PR DESCRIPTION
Explicitly calling embedding layer in llava_next.py as opposed to doing this in the language_model [component](https://github.com/foundation-model-stack/foundation-model-stack/blob/main/fms/models/granite.py#L290)-- being ignored in AIU run for some reason, leading to incorrect output otherwise.