### PR TITLE
:zap: remove extra kv cache validation

### DIFF
--- a/fms/utils/spyre/paged.py
+++ b/fms/utils/spyre/paged.py
@@ -9,6 +9,7 @@ from fms.modules.attention import (
 import torch
 
 from torch.library import custom_op
+from torch import compiler
 import torch.nn.functional as F
 
 
@@ -212,6 +213,11 @@ def __spyre_paged_validate_attn_kwargs_op(
     left_padded_prompt_mask = attn_kwargs.get("left_padded_prompt_mask", None)
     if left_padded_prompt_mask is not None:
         assert input_ids.shape[0] == left_padded_prompt_mask.shape[0]
+
+    if compiler.is_compiling():
+        # When compiling for spyre, don't run expensive KV cache validation.
+        # The input `past_key_value_states` aren't actually sent to the device when running on spyre
+        return
 
     if past_key_value_states is not None:
         for k, v in past_key_value_states:


### PR DESCRIPTION
When running spyre paged attention on real spyre devices, the KV cache tensors aren't actually transferred to and from the device. The KV cache is all managed entirely spyre-side and not on the host. This means that users only need to compile the model with valid `past_key_value_states`, and once the model is compiled they can continue just passing in a dummy value.

In the validation op for spyre_paged_attention, there is a super expensive validation loop that validates every layer of the kv cache against every other layer of the kv cache. Because this is inside the model code that needs to be traced during every forward pass to load the correct compiled program to run, this adds extra overhead to all models running on spyre for no benefit.

This PR guards against adding the kv cache validation during `torch.compile()`, but leaves it in for eager use. This allows users to validate that their inputs to `past_kev_value_states` are valid without compilation, and then avoid the overhead when actually running in production. We could add another `attention_kwarg` to opt-in to this behavior if needed, but I want to keep the change minimal and not require opt-in for users to see the performance benefit.

Benchmarking results with performance improvements on spyre hardware available internally
