### PR TITLE
feat(trust-remote-code): Add trust_remote_code support for HuggingFace model loading

### DIFF
--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -112,15 +112,10 @@ def __maybe_infer_model_variant(
 
         logger.info(f"inferring model configuration from {model_path_or_variant}")
 
-        # Only pass kwargs that are accepted by infer_model_configuration
-        infer_kwargs = {}
-        if "trust_remote_code" in kwargs:
-            infer_kwargs["trust_remote_code"] = kwargs["trust_remote_code"]
-
         extra_kwargs = infer_model_configuration(
             model_path_or_variant,
             download_weights=is_hf_pretrained and variant is not None,  # type: ignore[arg-type]
-            **infer_kwargs,
+            trust_remote_code=kwargs.get("trust_remote_code", False),
         )
         architecture = extra_kwargs.pop("architecture")
         variant = extra_kwargs.pop("variant")

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -112,9 +112,15 @@ def __maybe_infer_model_variant(
 
         logger.info(f"inferring model configuration from {model_path_or_variant}")
 
+        # Only pass kwargs that are accepted by infer_model_configuration
+        infer_kwargs = {}
+        if "trust_remote_code" in kwargs:
+            infer_kwargs["trust_remote_code"] = kwargs["trust_remote_code"]
+
         extra_kwargs = infer_model_configuration(
             model_path_or_variant,
             download_weights=is_hf_pretrained and variant is not None,  # type: ignore[arg-type]
+            **infer_kwargs,
         )
         architecture = extra_kwargs.pop("architecture")
         variant = extra_kwargs.pop("variant")

--- a/fms/models/hf/utils.py
+++ b/fms/models/hf/utils.py
@@ -120,6 +120,7 @@ def mask_2d_to_3d_bidirectional(
 def infer_model_configuration(
     model_id_or_path: str | os.PathLike,
     download_weights: bool = True,
+    trust_remote_code: bool = False,
 ) -> Dict[str, Any]:
     # if the path does not exist, download it from huggingface and get the local path
     if not os.path.exists(model_id_or_path):
@@ -165,7 +166,7 @@ def infer_model_configuration(
     else:
         model_path = str(model_id_or_path)
 
-    config = AutoConfig.from_pretrained(model_path)
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=trust_remote_code)
 
     ## HACK to map Mistral3ForConditionalGeneration to Ministral3 class successfully
 


### PR DESCRIPTION
## Description

This PR enables loading HuggingFace models that require custom code execution by adding trust_remote_code parameter support throughout the model loading pipeline.

Depends on https://github.com/torch-spyre/sendnn-inference/pull/953

## Changes:
  
- `fms/models/hf/utils.py`: Added `trust_remote_code: bool = False` parameter to `infer_model_configuration()`. The parameter is passed to `AutoConfig.from_pretrained()` to enable loading models with custom architectures.

- `fms/models/__init__.py`: Updated `__maybe_infer_model_variant()` to forward `trust_remote_code` from `kwargs` to `infer_model_configuration()` when loading HF pretrained/configured models.

## Backward Compatibility:

The default value is `False`, maintaining existing behavior for models that don't require remote code execution.