### PR TITLE
:bug: Run weight expansion before RoPE permutation and use correct head size

### DIFF
--- a/fms/models/hf/__init__.py
+++ b/fms/models/hf/__init__.py
@@ -37,7 +37,8 @@ from fms.models.gpt_oss import GptOss, GptOssHeadless
 from transformers import __version__ as tf_version
 
 # Register Ministral3 if transformers is less than 5.x.x
-if Version(tf_version) < Version("5.0.0"):
+# Use .major to correctly exclude pre-release 5.x versions (e.g. 5.0.0rc1 < 5.0.0 in PEP 440)
+if Version(tf_version).major < 5:
     from transformers import AutoConfig, AutoModelForCausalLM
 
     # This applies FMS serialization adapters (RoPE fix, weight fusion, etc.)
@@ -95,13 +96,14 @@ _headless_models = [
     HFAdaptedGptOssHeadless,
 ]
 
-# Add Ministral3 headless if available
-try:
-    from fms.models.hf.ministral3 import HFAdaptedMinistral3Headless
+# Add Ministral3 headless if available and transformers < 5 (ministral3 is built-in in tf5+)
+if Version(tf_version).major < 5:
+    try:
+        from fms.models.hf.ministral3 import HFAdaptedMinistral3Headless
 
-    _headless_models.append(HFAdaptedMinistral3Headless)
-except ImportError:
-    pass
+        _headless_models.append(HFAdaptedMinistral3Headless)
+    except ImportError:
+        pass
 
 """
 list of all causal-lm HF-Adapted models used in registration
@@ -114,13 +116,14 @@ _causal_lm_models = [
     HFAdaptedGptOssForCausalLM,
 ]
 
-# Add Ministral3 causal LM if available
-try:
-    from fms.models.hf.ministral3 import HFAdaptedMinistral3ForCausalLM
+# Add Ministral3 causal LM if available and transformers < 5 (ministral3 is built-in in tf5+)
+if Version(tf_version).major < 5:
+    try:
+        from fms.models.hf.ministral3 import HFAdaptedMinistral3ForCausalLM
 
-    _causal_lm_models.append(HFAdaptedMinistral3ForCausalLM)
-except ImportError:
-    pass
+        _causal_lm_models.append(HFAdaptedMinistral3ForCausalLM)
+    except ImportError:
+        pass
 
 """
 list of all masked-lm HF-Adapted models used in registration

--- a/fms/models/hf/gpt_oss/configuration_gpt_oss_hf.py
+++ b/fms/models/hf/gpt_oss/configuration_gpt_oss_hf.py
@@ -72,7 +72,7 @@ class HFAdaptedGptOssConfig(PretrainedConfig):
         self.hidden_dim = hidden_dim
         self.head_dim = head_dim
         self.layer_types = layer_types
-        if self.layer_types is None:
+        if self.layer_types is None or len(self.layer_types) != self.nlayers:
             self.layer_types = [
                 "sliding_attention" if bool((i + 1) % 2) else "full_attention"
                 for i in range(self.nlayers)

--- a/fms/models/hf/mixtral/__init__.py
+++ b/fms/models/hf/mixtral/__init__.py
@@ -1,5 +1,7 @@
 import torch
+from packaging.version import Version
 from transformers import MixtralConfig, MixtralForCausalLM
+from transformers import __version__ as tf_version
 
 from fms.models.hf.mixtral.modeling_mixtral_hf import (
     HFAdaptedMixtralConfig,
@@ -71,25 +73,38 @@ def convert_to_hf(
             oss_hf_layer.self_attn.o_proj.weight.copy_(fms_hf_layer.attn.dense.weight)
 
             # MoE SwiGLU
-            oss_hf_layer.block_sparse_moe.gate.weight.copy_(
-                fms_hf_layer.ff_sub_layer.gate.weight
-            )
-            for expert_idx, expert_layer in enumerate(
-                oss_hf_layer.block_sparse_moe.experts
-            ):
-                expert_layer.w1.weight.copy_(
-                    fms_hf_layer.ff_sub_layer.cond_ffn.w13.chunk(2, dim=1)[0][
-                        expert_idx
-                    ]
+            if Version(tf_version).major >= 5:
+                # transformers 5.x: block_sparse_moe renamed to mlp; experts
+                # stored as batched 3D tensors instead of a list of modules
+                oss_hf_layer.mlp.gate.weight.copy_(
+                    fms_hf_layer.ff_sub_layer.gate.weight
                 )
-                expert_layer.w3.weight.copy_(
-                    fms_hf_layer.ff_sub_layer.cond_ffn.w13.chunk(2, dim=1)[1][
-                        expert_idx
-                    ]
+                oss_hf_layer.mlp.experts.gate_up_proj.copy_(
+                    fms_hf_layer.ff_sub_layer.cond_ffn.w13
                 )
-                expert_layer.w2.weight.copy_(
-                    fms_hf_layer.ff_sub_layer.cond_ffn.w2[expert_idx]
+                oss_hf_layer.mlp.experts.down_proj.copy_(
+                    fms_hf_layer.ff_sub_layer.cond_ffn.w2
                 )
+            else:
+                oss_hf_layer.block_sparse_moe.gate.weight.copy_(
+                    fms_hf_layer.ff_sub_layer.gate.weight
+                )
+                for expert_idx, expert_layer in enumerate(
+                    oss_hf_layer.block_sparse_moe.experts
+                ):
+                    expert_layer.w1.weight.copy_(
+                        fms_hf_layer.ff_sub_layer.cond_ffn.w13.chunk(2, dim=1)[0][
+                            expert_idx
+                        ]
+                    )
+                    expert_layer.w3.weight.copy_(
+                        fms_hf_layer.ff_sub_layer.cond_ffn.w13.chunk(2, dim=1)[1][
+                            expert_idx
+                        ]
+                    )
+                    expert_layer.w2.weight.copy_(
+                        fms_hf_layer.ff_sub_layer.cond_ffn.w2[expert_idx]
+                    )
 
             # layer norm
             oss_hf_layer.input_layernorm.weight.copy_(fms_hf_layer.ln.weight)

--- a/fms/models/hf/mixtral/configuration_mixtral_hf.py
+++ b/fms/models/hf/mixtral/configuration_mixtral_hf.py
@@ -35,6 +35,7 @@ class HFAdaptedMixtralConfig(PretrainedConfig):
         num_experts: int = 8,
         top_k_experts: int = 2,
         max_expected_seq_len: int = 32768,
+        pad_token_id: Optional[int] = None,
         bos_token_id: int = 1,
         eos_token_id: int = 2,
         p_dropout: float = 0.0,
@@ -58,6 +59,7 @@ class HFAdaptedMixtralConfig(PretrainedConfig):
         self.max_expected_seq_len = max_expected_seq_len
         self.use_cache = use_cache
         super().__init__(
+            pad_token_id=pad_token_id,
             eos_token_id=eos_token_id,
             bos_token_id=bos_token_id,
             is_decoder=is_decoder,

--- a/fms/models/hf/mixtral/modeling_mixtral_hf.py
+++ b/fms/models/hf/mixtral/modeling_mixtral_hf.py
@@ -4,7 +4,9 @@ from typing_extensions import Unpack
 from fms.modules.attention import SDPAAttentionKwargs
 import torch
 import torch.nn as nn
+from packaging.version import Version
 from transformers import PretrainedConfig
+from transformers import __version__ as tf_version
 from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions
 
 from fms.models.hf.lm_head_mixins import LMHeadModelLMHeadMixin
@@ -55,7 +57,21 @@ class HFAdaptedMixtralHeadless(HFDecoderModelArchitecture):
     config_class = HFAdaptedMixtralConfig
     base_model_prefix = "hf_adapted_mixtral"
 
-    _tied_weights_keys = ["decoder.model.embedding.weight", "embedding.weight"]
+    ## Address transformers API changes
+    if Version(tf_version) >= Version("5.0.0"):
+        # embedding.weight is the alias; decoder.model.embedding.weight is the canonical (saved) copy
+        _tied_weights_keys = {
+            "embedding.weight": "decoder.model.embedding.weight",
+        }
+        _keys_to_ignore_on_load_missing = [r"embedding\.weight"]
+
+        def get_expanded_tied_weights_keys(self, all_submodels: bool = False) -> dict:
+            # tie_word_embeddings=False prevents the base class from returning our mapping;
+            # override to always expose the module-level alias so transformers 5.x can
+            # protect embedding.weight from _initialize_missing_keys reinitialization.
+            return {"embedding.weight": "decoder.model.embedding.weight"}
+    else:
+        _tied_weights_keys = ["decoder.model.embedding.weight", "embedding.weight"]
     _keys_to_ignore_on_save = ["embedding.weight"]
 
     def __init__(

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -536,11 +536,7 @@ def _hf_to_fms_rope(
         # Use head_dim from config, not emb_dim // nheads. When weight_expansion
         # has already run (e.g. 64->128 for Granite 3.3 2B on Spyre), the weights
         # already have the expanded head_dim and the permutation must match it.
-        # head_size = model_config.head_dim
-        head_size = model_config.emb_dim // model_config.nheads
-        print("===" * 20)
-        print("head size: ", head_size)
-        print("===" * 20)
+        head_size = model_config.head_dim
         linear_type_str = "torch_linear"
         if model_config.linear_config:
             linear_type_str = get_linear_type(

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -612,5 +612,10 @@ serialization.register_adapter_step(
 serialization.register_adapter(
     _architecture_name,
     "hf",
-    ["hf_to_fms_names", "weight_expansion_for_mismatched_head_dim", "hf_to_fms_rope", "weight_fusion"],
+    [
+        "hf_to_fms_names",
+        "weight_expansion_for_mismatched_head_dim",
+        "hf_to_fms_rope",
+        "weight_fusion",
+    ],
 )

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -536,7 +536,11 @@ def _hf_to_fms_rope(
         # Use head_dim from config, not emb_dim // nheads. When weight_expansion
         # has already run (e.g. 64->128 for Granite 3.3 2B on Spyre), the weights
         # already have the expanded head_dim and the permutation must match it.
-        head_size = model_config.head_dim
+        # head_size = model_config.head_dim
+        head_size = model_config.emb_dim // model_config.nheads
+        print("===" * 20)
+        print("head size: ", head_size)
+        print("===" * 20)
         linear_type_str = "torch_linear"
         if model_config.linear_config:
             linear_type_str = get_linear_type(

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -533,7 +533,10 @@ def _hf_to_fms_rope(
         model_config = model_config.text_config
 
     if model_config:
-        head_size = model_config.emb_dim // model_config.nheads
+        # Use head_dim from config, not emb_dim // nheads. When weight_expansion
+        # has already run (e.g. 64->128 for Granite 3.3 2B on Spyre), the weights
+        # already have the expanded head_dim and the permutation must match it.
+        head_size = model_config.head_dim
         linear_type_str = "torch_linear"
         if model_config.linear_config:
             linear_type_str = get_linear_type(
@@ -609,5 +612,5 @@ serialization.register_adapter_step(
 serialization.register_adapter(
     _architecture_name,
     "hf",
-    ["hf_to_fms_names", "hf_to_fms_rope", "weight_fusion"],
+    ["hf_to_fms_names", "weight_expansion_for_mismatched_head_dim", "hf_to_fms_rope", "weight_fusion"],
 )

--- a/fms/utils/evaluation.py
+++ b/fms/utils/evaluation.py
@@ -48,7 +48,7 @@ class FMSEvalHarnessLM(LM):
         self.batch_size = batch_size
         self._rank = rank
         self._world_size = world_size
-        self.device = device
+        self._device = device
 
         # workaround for https://github.com/EleutherAI/lm-evaluation-harness/issues/1333
         # until the fix is in a release

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -221,7 +221,7 @@ class _HFTokenizer(BaseTokenizer):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.tokenizer.convert_ids_to_tokens(ids)
+        return self.tokenizer.convert_ids_to_tokens(ids.tolist())
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
         warnings.warn(

--- a/fms/utils/tokenizers.py
+++ b/fms/utils/tokenizers.py
@@ -221,7 +221,8 @@ class _HFTokenizer(BaseTokenizer):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.tokenizer.convert_ids_to_tokens(ids.tolist())
+        ids_list = ids.tolist() if isinstance(ids, torch.Tensor) else ids
+        return self.tokenizer.convert_ids_to_tokens(ids_list)
 
     def convert_tokens_to_ids(self, tokens: Union[str, list[str]]):
         warnings.warn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
 "types-requests==2.32.0.20241016",
 "tqdm==4.67.1",
 "types-tqdm",
-"lm_eval==0.4.7",
+"lm_eval>0.4.7",
 "peft==0.14.0",
 "fms-model-optimizer>=0.8.1",
 ]


### PR DESCRIPTION
### Change
- Move `weight_expansion_for_mismatched_head_dim` before `hf_to_fms_rope` in the `llava_next` HF adapter chain. weight expansion (head_dim 64→128 for Granite 3.3 2B) was running after the RoPE permutation, so the permutation was operating on 64-dim weights and producing the wrong interleaved layout. Expansion must happen first so the permutation sees the full 128-dim weights.
- Use `model_config.head_dim` instead of `emb_dim // nheads` as `head_size` in _hf_to_fms_rope. Using the wrong `head_size` caused `num_heads` to be computed as `64` instead of `32`, producing a completely incorrect permutation.
- Fix compatibility issue with transformers 5 and update lm_eval to support latest transformers


### Test via vLLM
#### Request Body
```json
{
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "<|system|>\nA chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n When does the line reach the peak?"
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "https://raw.githubusercontent.com/vis-nlp/ChartQA/main/ChartQA%20Dataset/test/png/08524901006324.png"
            }
          }
        ]
      }
    ],
	"temperature": 0.1
  }
```

#### Response Before
```
{
	"model": "ibm-granite/granite-vision-3.3-2b",
	"choices": [
		{
			"index": 0,
			"message": {
				"role": "assistant",
				"content": "2014000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
				"refusal": null,
				"annotations": null,
				"audio": null,
				"function_call": null,
				"tool_calls": [],
				"reasoning": null
			},
			"logprobs": null,
			"finish_reason": "length",
			"stop_reason": null,
			"token_ids": null
		}
	],
....
}
```


#### Response After Fix
```
{
	"model": "ibm-granite/granite-vision-3.3-2b",
	"choices": [
		{
			"index": 0,
			"message": {
				"role": "assistant",
				"content": "2014",
				"refusal": null,
				"annotations": null,
				"audio": null,
				"function_call": null,
				"tool_calls": [],
				"reasoning": null
			},
			"logprobs": null,
			"finish_reason": "stop",
			"stop_reason": null,
			"token_ids": null
		}
	],
...
}
```

