### PR TITLE
Remove contiguous for eager_spyre

### DIFF
--- a/fms/modules/positions.py
+++ b/fms/modules/positions.py
@@ -278,7 +278,7 @@ class RotaryEmbedding(PositionEncoder):
                         torch.cos(freqs),
                     ],
                     dim=1,
-                ).view(freqs.shape[0], 2, 2, freqs.shape[1]).contiguous().to(dtype=torch.float16) # S, D/2, 2, 2 -> S, 2, 2, D/2
+                ).view(freqs.shape[0], 2, 2, freqs.shape[1]).to(dtype=torch.float16) # S, D/2, 2, 2 -> S, 2, 2, D/2
 
         return alpha
 

--- a/fms/utils/generation.py
+++ b/fms/utils/generation.py
@@ -339,12 +339,12 @@ def generate(
 
         if model.head.weight.device.type == "spyre":
             alpha = model.base_model.rot_emb.compute_freqs_cis(torch.device("spyre"), max_seq_len)
-            kwargs["selected_freqs"] = model.base_model.rot_emb.cached_freqs[0][alpha][kwargs["position_ids"]].contiguous().to("spyre")
+            kwargs["selected_freqs"] = model.base_model.rot_emb.cached_freqs[0][alpha][kwargs["position_ids"]].to("spyre")
             kwargs["mask"] = kwargs["mask"].to(dtype=torch.float16).to("spyre")
             model_input_ids = input_ids.to("spyre")
         else:
             alpha = model.base_model.rot_emb.compute_freqs_cis(torch.device("cpu"), max_seq_len)
-            kwargs["selected_freqs"] = model.base_model.rot_emb.cached_freqs[None][alpha][kwargs["position_ids"]].contiguous()
+            kwargs["selected_freqs"] = model.base_model.rot_emb.cached_freqs[None][alpha][kwargs["position_ids"]]
             model_input_ids = input_ids
         output = model(model_input_ids, **kwargs)
         if use_cache:


### PR DESCRIPTION
This PR removes 3 contiguous that are no longer needed now that torch spyre implements restickify.

I expected to see some restickifies inserted to compensate for the removal of the contiguous, but none are needed.  It seems that these contiguous were all no-ops at this point.

I have run granite with batch size 1 & 2 and both succeed.