### PR TITLE
Fix llava next text

### DIFF
--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -405,6 +405,7 @@ class LlavaNext(nn.Module):
 
         # No image data to pre-process
         if pixel_values is None or pixel_values.size(0) == 0:
+            input_ids = self.language_model.base_model.embedding(input_ids)
             return input_ids, kwargs
 
         inputs = kwargs.get("inputs")


### PR DESCRIPTION
### Changes

llava_next model was incorrectly passing on input_ids instead of embeddings in case of text only inputs. This PR fixes that by invoking embedding resolution for text only calls