### PR TITLE
Add vision only mode

### DIFF
--- a/docs/enable_vision_only_load.md
+++ b/docs/enable_vision_only_load.md
@@ -82,23 +82,6 @@ get_model(..., vision_only=True)
 - `vision_tower` (SiglipVision)
 - `multi_modal_projector` (LlavaNextMultiModalProjector)
 
-Text embeddings are accessed in `prepare_inputs_for_generation` directly as
-`self.language_model.base_model.embedding(input_ids)` — the same pattern as
-`Mistral3`. Completing `vision_only` support here would require: a `vision_only` flag in
-`__init__`, a conditional `text_embedding`, guarded `reset_parameters` /
-`post_init` calls, and an extraction of the inline embedding accesses in
-`prepare_inputs_for_generation` into a `_get_text_embeddings` helper.
-
-`LlavaNext` already carries a `VISION_ONLY_HF_PREFIXES` class attribute
-(added alongside `Mistral3`), so `get_model` will pick up the right prefix
-filter automatically once the constructor-side changes are made. The HF prefix
-names happen to be identical to `Mistral3` because both architectures use the
-same top-level key naming convention (`vision_tower.`, `multi_modal_projector.`,
-`language_model.model.embed_tokens.`).
-
-The constructor-side changes are not included in this work; the model is noted
-here as the natural next candidate.
-
 ---
 
 ## Guide for Future Multimodal Models

--- a/docs/enable_vision_only_load.md
+++ b/docs/enable_vision_only_load.md
@@ -1,0 +1,194 @@
+# Enable Vision-Only Model Loading in FMS
+
+## Motivation
+
+When running a multimodal model via sendnn-inference, we want to enable separate vision encoder execution to allow parallel and non-blocking invocation of encoder model, separate from rest of the decoder model. To implement this capability, we need a way to only load vision part of multimodal model, for example, load `vision_tower` for Ministral3. This work is to add an optional `vision_only` flag when we load model via FMS's `get_model` function.
+
+
+**Example use-case**:
+
+```python
+fms_model = get_model("hf_pretrained", model_path=..., vision_only=True)
+```
+
+This will load and allocate only the three vision-relevant components, skipping the LLM decoder stack entirely. These three components would be:
+- `vision_tower`
+- `multi_modal_projector`
+- `language_model.base_model.embedding` (text embedding, needed to merge image tokens into text embedding space)
+
+## Design
+
+### Overview
+
+The feature is implemented as a single optional `vision_only: bool = False` flag threaded through four layers: the public `get_model` entry point, the model constructors, the weight-loading loop, and the forward helpers. All existing callers are unaffected because the flag defaults to `False`.
+
+### Model construction (`Mistral3` / `Ministral3`)
+
+When `vision_only=True` the model constructor skips building the full LLM decoder stack (`language_model`). Instead it allocates only:
+
+- `vision_tower` — the PixtralVisionModel image encoder
+- `multi_modal_projector` — the linear projection from vision to text space
+- `text_embedding` — a standalone `nn.Embedding` that replaces `language_model.base_model.embedding`
+
+The standalone embedding is necessary because `prepare_inputs_for_generation` must merge image feature tokens into the text embedding space even when there is no decoder. A `_vision_only` instance flag is stored so that `_get_text_embeddings`, `reset_parameters`, and `post_init` can conditionally route through the standalone embedding rather than the full language model.
+
+`Ministral3` overrides `__init__` directly, so it receives the same treatment independently. The shared helpers (`_get_text_embeddings`, `reset_parameters`, `post_init`) are defined on `Mistral3` and inherited, so the guard logic is written once.
+
+### Weight loading (`load_state_dict_into_model`)
+
+A new `key_prefix_filter` parameter accepts a tuple of checkpoint key prefixes. When provided, any key in the state dict that does not start with one of those prefixes is skipped **before** the HF→FMS adapter runs. Because the state dict is a `LazySafetensorsDict`, filtered keys are never read from disk — their shard files are never opened, which is the primary memory and I/O saving.
+
+The filter operates on HF-side key names (before the adapter renames them) because the adapter has not been applied at the point of filtering.
+
+### Entry point (`get_model`)
+
+`get_model` extracts `vision_only` from its `**kwargs` before passing the remainder to `__maybe_infer_model_variant`, so the flag is not misinterpreted as a model configuration field. After variant inference, it re-injects `vision_only` into the `extra_args` dict that is forwarded to the model constructor. It also selects the appropriate `key_prefix_filter` value and passes it to `load_state_dict_into_model`.
+
+### Data flow summary
+
+```
+get_model(..., vision_only=True)
+    │
+    ├─ pops vision_only from kwargs
+    ├─ infers architecture/variant as normal
+    ├─ passes vision_only → model constructor
+    │       └─ skips language_model; creates text_embedding instead
+    │
+    └─ passes key_prefix_filter → load_state_dict_into_model
+            └─ skips LLM decoder keys before adapter; tensor files never opened
+```
+
+---
+
+## Key Prefix Mapping Reference
+
+| Component | HF checkpoint prefix | FMS prefix after adapter |
+|---|---|---|
+| Vision tower | `vision_tower.` | `vision_tower.` |
+| Projector | `multi_modal_projector.` | `multi_modal_projector.` |
+| Text embedding | `language_model.model.embed_tokens.` | `language_model.base_model.embedding.` |
+| LLM decoder (skipped) | `language_model.model.layers.` | `language_model.base_model.layers.` |
+| LLM head (skipped) | `language_model.lm_head.` | `language_model.head.` |
+
+---
+
+## Implications for Existing Models
+
+### `LlavaNext` (`fms/models/llava_next.py`)
+
+`LlavaNext` has the same three-component structure as `Mistral3`:
+
+- `language_model` (Granite LLM)
+- `vision_tower` (SiglipVision)
+- `multi_modal_projector` (LlavaNextMultiModalProjector)
+
+Text embeddings are accessed in `prepare_inputs_for_generation` directly as
+`self.language_model.base_model.embedding(input_ids)` — the same pattern as
+`Mistral3`. Completing `vision_only` support here would require: a `vision_only` flag in
+`__init__`, a conditional `text_embedding`, guarded `reset_parameters` /
+`post_init` calls, and an extraction of the inline embedding accesses in
+`prepare_inputs_for_generation` into a `_get_text_embeddings` helper.
+
+`LlavaNext` already carries a `VISION_ONLY_HF_PREFIXES` class attribute
+(added alongside `Mistral3`), so `get_model` will pick up the right prefix
+filter automatically once the constructor-side changes are made. The HF prefix
+names happen to be identical to `Mistral3` because both architectures use the
+same top-level key naming convention (`vision_tower.`, `multi_modal_projector.`,
+`language_model.model.embed_tokens.`).
+
+The constructor-side changes are not included in this work; the model is noted
+here as the natural next candidate.
+
+---
+
+## Guide for Future Multimodal Models
+
+Any FMS multimodal model that wants to support `vision_only=True` needs to
+implement the following four things consistently.
+
+### 1. Model constructor
+
+Add a `vision_only: bool = False` parameter. Store it as `self._vision_only`.
+Conditionally construct the LLM:
+
+```python
+self._vision_only = vision_only
+if not vision_only:
+    self.language_model = <LLMClass>(...)
+else:
+    # Minimal embedding needed to merge image tokens into text space
+    self.text_embedding = nn.Embedding(
+        self.config.text_config.src_vocab_size,
+        self.config.text_config.emb_dim,
+    )
+self.vision_tower = <VisionEncoder>(...)
+self.multi_modal_projector = <Projector>(...)
+```
+
+Always construct `vision_tower` and `multi_modal_projector` unconditionally.
+
+### 2. Text embedding helper
+
+If the model has a `_get_text_embeddings` (or equivalent inline logic in
+`prepare_inputs_for_generation`), route through the standalone embedding when
+in vision-only mode:
+
+```python
+def _get_text_embeddings(self, input_ids, input_embeds):
+    if input_embeds is not None:
+        return input_embeds
+    if self._vision_only:
+        return self.text_embedding(input_ids)
+    return self.language_model.base_model.embedding(input_ids)
+```
+
+If the embedding access is inlined (as in `LlavaNext`), extract it into a
+helper first so the guard can be written in one place.
+
+### 3. `reset_parameters` and `post_init`
+
+Guard any call that touches `language_model`:
+
+```python
+def reset_parameters(self):
+    if not self._vision_only:
+        self.language_model.reset_parameters()
+    self.vision_tower.reset_parameters()
+
+def post_init(self):
+    if not self._vision_only:
+        self.language_model.post_init()
+    self.vision_tower.post_init()
+```
+
+### 4. `VISION_ONLY_HF_PREFIXES` class attribute
+
+Define a class-level tuple of HF-side checkpoint prefixes that covers only the
+vision components and the text embedding for the architecture. This lives on
+the model class itself, not in `__init__.py`, so each model owns its own
+prefix list.
+
+```python
+class MyMultimodalModel(nn.Module):
+    VISION_ONLY_HF_PREFIXES: tuple = (
+        "<vision_tower_hf_prefix>.",
+        "<projector_hf_prefix>.",
+        "<embed_tokens_hf_prefix>.",   # HF name for the text token embedding
+        "<embed_tokens_fms_prefix>.",  # FMS name, in case checkpoint is already FMS-formatted
+    )
+```
+
+`get_model` discovers the constant via `getattr(fms_model, "VISION_ONLY_HF_PREFIXES", None)`
+and passes it as `key_prefix_filter` to `load_state_dict_into_model`. If the
+attribute is absent (model does not support `vision_only`), `get_model` will
+pass `None` and all keys are loaded as normal — no error, no silent data loss.
+
+### Checklist
+
+| Step | What to do |
+|---|---|
+| Model `__init__` | Add `vision_only` param; conditionally skip LLM; create `text_embedding` |
+| `_get_text_embeddings` | Route through `self.text_embedding` when `_vision_only` |
+| `reset_parameters` / `post_init` | Guard calls to `language_model` |
+| `__init__.py` constant | Define `_<ARCH>_VISION_ONLY_HF_PREFIXES` with correct HF key prefixes |
+| `get_model` | Select and pass the right prefix constant for the architecture |

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -346,6 +346,7 @@ def get_model(
         device = torch.device(device_type)
 
     extra_args = kwargs
+    vision_only = extra_args.pop("vision_only", False)
     # TODO: streamline this logic
     data_type_parsed: Optional[torch.dtype] = None
     if isinstance(data_type, str):  # convert str to torch.dtype
@@ -388,6 +389,10 @@ def get_model(
         source,
         **kwargs,
     )
+
+    # Forward vision_only to the model constructor (popped before infer to avoid
+    # being misinterpreted as a config kwarg by __maybe_infer_model_variant).
+    extra_args["vision_only"] = vision_only
 
     lazy_sd: MutableMapping[str, Any] = {}
     if model_path is not None:
@@ -460,6 +465,7 @@ def get_model(
             checkpoint_sharding=checkpoint_sharding,
             initial_device=initial_device,
             rank=rank,
+            key_prefix_filter=getattr(fms_model, "VISION_ONLY_HF_PREFIXES", None) if vision_only else None,
         )
     else:
         # move from meta device to real device

--- a/fms/models/__init__.py
+++ b/fms/models/__init__.py
@@ -465,7 +465,9 @@ def get_model(
             checkpoint_sharding=checkpoint_sharding,
             initial_device=initial_device,
             rank=rank,
-            key_prefix_filter=getattr(fms_model, "VISION_ONLY_HF_PREFIXES", None) if vision_only else None,
+            key_prefix_filter=getattr(fms_model, "VISION_ONLY_HF_PREFIXES", None)
+            if vision_only
+            else None,
         )
     else:
         # move from meta device to real device

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -145,8 +145,8 @@ class LlavaNext(nn.Module):
     VISION_ONLY_HF_PREFIXES: tuple = (
         "vision_tower.",
         "multi_modal_projector.",
-        "language_model.model.embed_tokens.",  # HF name
-        "language_model.base_model.embedding.",  # FMS name (if checkpoint is already FMS)
+        "language_model.model.embed_tokens.",  # HF name → remapped to text_embedding by adapter
+        "text_embedding.",  # FMS name when checkpoint is already from a vision_only model
     )
 
     def __init__(
@@ -501,7 +501,14 @@ def _weight_fusion(
     return new_sd
 
 
-def _hf_to_fms_names(input_sd: Mapping[str, Any], **kwargs) -> Mapping[str, Any]:
+def _hf_to_fms_names(
+    input_sd: Mapping[str, Any], vision_only: bool = False, **kwargs
+) -> Mapping[str, Any]:
+    embed_dst = (
+        "text_embedding.weight"
+        if vision_only
+        else "language_model.base_model.embedding.weight"
+    )
     replacements = [
         # vision
         (r"vision_tower\.vision_model\.head", "vision_tower.head"),
@@ -522,10 +529,7 @@ def _hf_to_fms_names(input_sd: Mapping[str, Any], **kwargs) -> Mapping[str, Any]
         (r"mlp\.fc2", "mlp.w2"),
         # language
         (r"language_model\.lm_head\.weight", "language_model.head.weight"),
-        (
-            r"language_model.model.embed_tokens.weight",
-            "language_model.base_model.embedding.weight",
-        ),
+        (r"language_model.model.embed_tokens.weight", embed_dst),
         (r"language_model.model.norm", "language_model.base_model.dec_norm"),
         (r"language_model.model.layers", "language_model.base_model.layers"),
         (r"self_attn\.o_proj", "attn.dense"),

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -239,6 +239,8 @@ class LlavaNext(nn.Module):
     def unpad_image(self, tensor: torch.Tensor, original_image_size: torch.Tensor):
         if not isinstance(original_image_size, (list, tuple)):
             original_size = original_image_size.tolist()
+        else:
+            original_size = original_image_size
         original_height, original_width = original_size
         current_height, current_width = tensor.shape[1:]
 
@@ -266,6 +268,8 @@ class LlavaNext(nn.Module):
     ):
         if not isinstance(original_image_size, (list, tuple)):
             original_size = original_image_size.tolist()
+        else:
+            original_size = original_image_size
 
         original_height, original_width = original_size
         best_fit = None

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -216,7 +216,11 @@ class LlavaNext(nn.Module):
         return self.config
 
     def reset_parameters(self):
-        nn.init.xavier_uniform_(self.image_newline.data)
+        # image_newline is 1-D so normal_ matches the construction-time init
+        nn.init.normal_(
+            self.image_newline,
+            std=1 / math.sqrt(self.config.text_config.emb_dim),
+        )
         if not self._vision_only:
             self.language_model.reset_parameters()
         self.vision_tower.reset_parameters()

--- a/fms/models/llava_next.py
+++ b/fms/models/llava_next.py
@@ -139,10 +139,21 @@ class LlavaNextMultiModalProjector(nn.Module):
 
 
 class LlavaNext(nn.Module):
+    # HF-side checkpoint key prefixes to load when vision_only=True.
+    # Covers vision encoder, projector, and the text embedding needed for
+    # image-token merging. LLM decoder shard files are never opened.
+    VISION_ONLY_HF_PREFIXES: tuple = (
+        "vision_tower.",
+        "multi_modal_projector.",
+        "language_model.model.embed_tokens.",  # HF name
+        "language_model.base_model.embedding.",  # FMS name (if checkpoint is already FMS)
+    )
+
     def __init__(
         self,
         config: Optional[LlavaNextConfig] = None,
         distributed_strategy: DistributedStrategy = NoOpStrategy,
+        vision_only: bool = False,
         **kwargs,
     ):
         super(LlavaNext, self).__init__()
@@ -159,6 +170,7 @@ class LlavaNext(nn.Module):
             self.config.vision_config.fused_weights = False
 
         self.distributed_strategy = distributed_strategy
+        self._vision_only = vision_only
 
         if not isinstance(self.config.vision_config, SiglipVisionConfig):
             print(
@@ -169,11 +181,19 @@ class LlavaNext(nn.Module):
                 "FMS implementation of LlavaNext currently supports only Granite language model"
             )
 
-        # Only supporting granite text decoder encoder for now
-        self.language_model = Granite(
-            self.config.text_config,
-            distributed_strategy,
-        )
+        if not vision_only:
+            # Only supporting granite text decoder encoder for now
+            self.language_model = Granite(
+                self.config.text_config,
+                distributed_strategy,
+            )
+        else:
+            # Only the embedding layer is needed to merge image tokens into
+            # text embedding space; the full LLM decoder stack is not constructed.
+            self.text_embedding = nn.Embedding(
+                self.config.text_config.src_vocab_size,
+                self.config.text_config.emb_dim,
+            )
 
         # Only supporting siglip vision encoder for now
         self.vision_tower = SiglipVision(
@@ -197,13 +217,20 @@ class LlavaNext(nn.Module):
 
     def reset_parameters(self):
         nn.init.xavier_uniform_(self.image_newline.data)
-        self.language_model.reset_parameters()
+        if not self._vision_only:
+            self.language_model.reset_parameters()
         self.vision_tower.reset_parameters()
         self.multi_modal_projector.reset_parameters()
 
     def post_init(self):
-        self.language_model.post_init()
+        if not self._vision_only:
+            self.language_model.post_init()
         self.vision_tower.post_init()
+
+    def _get_text_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self._vision_only:
+            return self.text_embedding(input_ids)
+        return self.language_model.base_model.embedding(input_ids)
 
     def unpad_image(self, tensor: torch.Tensor, original_image_size: torch.Tensor):
         if not isinstance(original_image_size, (list, tuple)):
@@ -395,9 +422,9 @@ class LlavaNext(nn.Module):
     ):
         # Use with arg `prepare_model_inputs_hook=model.prepare_inputs_for_generation` when calling generate()
 
-        if kwargs["use_cache"] and iteration > 0:
+        if kwargs.get("use_cache") and iteration > 0:
             # No need to process image data again in cached decoding stage.
-            input_ids = self.language_model.base_model.embedding(input_ids)
+            input_ids = self._get_text_embeddings(input_ids)
             return input_ids, kwargs
 
         pixel_values = kwargs.get("pixel_values")
@@ -405,7 +432,7 @@ class LlavaNext(nn.Module):
 
         # No image data to pre-process
         if pixel_values is None or pixel_values.size(0) == 0:
-            input_ids = self.language_model.base_model.embedding(input_ids)
+            input_ids = self._get_text_embeddings(input_ids)
             return input_ids, kwargs
 
         inputs = kwargs.get("inputs")
@@ -414,7 +441,7 @@ class LlavaNext(nn.Module):
 
         # embedded inputs supersede input_ids
         if inputs is None:
-            inputs = self.language_model.base_model.embedding(input_ids)
+            inputs = self._get_text_embeddings(input_ids)
 
         image_features = self.get_image_features(
             pixel_values,

--- a/fms/models/ministral3.py
+++ b/fms/models/ministral3.py
@@ -444,14 +444,18 @@ def _weight_fusion(
 serialization.register_adapter_step(_architecture_name, "weight_fusion", _weight_fusion)
 
 
-def _hf_to_fms_names(input_sd: Mapping[str, Any], **kwargs) -> Mapping[str, Any]:
+def _hf_to_fms_names(
+    input_sd: Mapping[str, Any], vision_only: bool = False, **kwargs
+) -> Mapping[str, Any]:
+    embed_dst = (
+        "text_embedding.weight"
+        if vision_only
+        else "language_model.base_model.embedding.weight"
+    )
     replacements = replacements = [
         # Language Model
         (r"^language_model.lm_head.weight", "language_model.head.weight"),
-        (
-            r"^language_model.model.embed_tokens.weight",
-            "language_model.base_model.embedding.weight",
-        ),
+        (r"^language_model.model.embed_tokens.weight", embed_dst),
         (r"^language_model.model.norm", "language_model.base_model.dec_norm"),
         (r"^language_model.model.layers", "language_model.base_model.layers"),
         (r"self_attn\.k_proj", "attn.in_proj.key"),

--- a/fms/models/ministral3.py
+++ b/fms/models/ministral3.py
@@ -362,6 +362,7 @@ class Ministral3(Mistral3):  # type: ignore[misc]
         self,
         config: Optional[Ministral3Config] = None,
         distributed_strategy: DistributedStrategy = NoOpStrategy,
+        vision_only: bool = False,
         **kwargs,
     ):
         nn.Module.__init__(self)
@@ -380,11 +381,20 @@ class Ministral3(Mistral3):  # type: ignore[misc]
             self.config.vision_config.fused_weights = False
 
         self.distributed_strategy = distributed_strategy
+        self._vision_only = vision_only
 
-        # Ministral3Text is structurally compatible with Mistral for the language model
-        self.language_model: Ministral3Text = Ministral3Text(  # type: ignore[assignment]
-            self.config.text_config, self.distributed_strategy
-        )
+        if not vision_only:
+            # Ministral3Text is structurally compatible with Mistral for the language model
+            self.language_model: Ministral3Text = Ministral3Text(  # type: ignore[assignment]
+                self.config.text_config, self.distributed_strategy
+            )
+        else:
+            # Only the embedding layer is needed to merge image tokens into
+            # text embedding space; the full LLM decoder stack is not constructed.
+            self.text_embedding = nn.Embedding(
+                self.config.text_config.src_vocab_size,
+                self.config.text_config.emb_dim,
+            )
         # Vision encoder and projector for multimodal features
         self.vision_tower = PixtralVisionModel(
             self.config.vision_config, self.distributed_strategy

--- a/fms/models/mistral3.py
+++ b/fms/models/mistral3.py
@@ -339,7 +339,9 @@ class Mistral3(nn.Module):
         image_positions = (input_ids[0] == self.config.image_token_index).nonzero(
             as_tuple=True
         )[0]
-        text_embeds[0, image_positions] = img_features.to(dtype)
+        text_embeds[0, image_positions] = img_features.to(
+            device=text_embeds.device, dtype=dtype
+        )
         return text_embeds
 
     def forward(

--- a/fms/models/mistral3.py
+++ b/fms/models/mistral3.py
@@ -154,10 +154,21 @@ class Mistral3MultiModalProjector(nn.Module):
 
 
 class Mistral3(nn.Module):
+    # HF-side checkpoint key prefixes to load when vision_only=True.
+    # Covers vision encoder, projector, and the text embedding needed for
+    # image-token merging. LLM decoder shard files are never opened.
+    VISION_ONLY_HF_PREFIXES: tuple = (
+        "vision_tower.",
+        "multi_modal_projector.",
+        "language_model.model.embed_tokens.",  # HF name
+        "language_model.base_model.embedding.",  # FMS name (if checkpoint is already FMS)
+    )
+
     def __init__(
         self,
         config: Optional[Mistral3Config] = None,
         distributed_strategy: DistributedStrategy = NoOpStrategy,
+        vision_only: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -176,11 +187,20 @@ class Mistral3(nn.Module):
             self.config.vision_config.fused_weights = False
 
         self.distributed_strategy = distributed_strategy
+        self._vision_only = vision_only
 
-        # Currently, we always use mistral for the LLM
-        self.language_model = Mistral(
-            self.config.text_config, self.distributed_strategy
-        )
+        if not vision_only:
+            # Currently, we always use mistral for the LLM
+            self.language_model = Mistral(
+                self.config.text_config, self.distributed_strategy
+            )
+        else:
+            # Only the embedding layer is needed to merge image tokens into
+            # text embedding space; the full LLM decoder stack is not constructed.
+            self.text_embedding = nn.Embedding(
+                self.config.text_config.src_vocab_size,
+                self.config.text_config.emb_dim,
+            )
         # Vision encoder and projector for multimodal features
         self.vision_tower = PixtralVisionModel(
             self.config.vision_config, self.distributed_strategy
@@ -197,12 +217,14 @@ class Mistral3(nn.Module):
         return self.config
 
     def reset_parameters(self):
-        self.language_model.reset_parameters()
+        if not self._vision_only:
+            self.language_model.reset_parameters()
         self.vision_tower.reset_parameters()
 
     def post_init(self):
-        # Language model post init will handle head tying etc.
-        self.language_model.post_init()
+        if not self._vision_only:
+            # Language model post init will handle head tying etc.
+            self.language_model.post_init()
         self.vision_tower.post_init()
 
     def prepare_inputs_for_generation(
@@ -245,6 +267,8 @@ class Mistral3(nn.Module):
         # Precomputed embeddings take priority over input IDs
         if input_embeds is not None:
             return input_embeds
+        if self._vision_only:
+            return self.text_embedding(input_ids)
         return self.language_model.base_model.embedding(input_ids)
 
     def _get_image_features(

--- a/fms/models/mistral3.py
+++ b/fms/models/mistral3.py
@@ -160,8 +160,8 @@ class Mistral3(nn.Module):
     VISION_ONLY_HF_PREFIXES: tuple = (
         "vision_tower.",
         "multi_modal_projector.",
-        "language_model.model.embed_tokens.",  # HF name
-        "language_model.base_model.embedding.",  # FMS name (if checkpoint is already FMS)
+        "language_model.model.embed_tokens.",  # HF name → remapped to text_embedding by adapter
+        "text_embedding.",  # FMS name when checkpoint is already from a vision_only model
     )
 
     def __init__(
@@ -397,14 +397,18 @@ def _weight_fusion(
 serialization.register_adapter_step(_architecture_name, "weight_fusion", _weight_fusion)
 
 
-def _hf_to_fms_names(input_sd: Mapping[str, Any], **kwargs) -> Mapping[str, Any]:
+def _hf_to_fms_names(
+    input_sd: Mapping[str, Any], vision_only: bool = False, **kwargs
+) -> Mapping[str, Any]:
+    embed_dst = (
+        "text_embedding.weight"
+        if vision_only
+        else "language_model.base_model.embedding.weight"
+    )
     replacements = replacements = [
         # Language Model
         (r"^language_model.lm_head.weight", "language_model.head.weight"),
-        (
-            r"^language_model.model.embed_tokens.weight",
-            "language_model.base_model.embedding.weight",
-        ),
+        (r"^language_model.model.embed_tokens.weight", embed_dst),
         (r"^language_model.model.norm", "language_model.base_model.dec_norm"),
         (r"^language_model.model.layers", "language_model.base_model.layers"),
         (r"self_attn\.k_proj", "attn.in_proj.key"),

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -542,6 +542,7 @@ def load_state_dict_into_model(
     # 3. Iterate over the weights and load them into the model
     used_keys = set()
     unused_keys = set()
+    filtered_keys = set()  # keys intentionally skipped by key_prefix_filter
     sd_keys = set(state_dict.keys())
 
     with torch.no_grad():
@@ -554,7 +555,7 @@ def load_state_dict_into_model(
             if key_prefix_filter is not None and not any(
                 key.startswith(p) for p in key_prefix_filter
             ):
-                unused_keys.add(key)
+                filtered_keys.add(key)
                 continue
 
             used_keys.add(key)
@@ -588,11 +589,28 @@ def load_state_dict_into_model(
             del partial_sd
             del fms_partial_sd
 
-    if unused_keys and rank == 0:
-        logger.warning(
-            f"Keys from checkpoint (adapted to FMS) "
-            f"not copied into model: {unused_keys}"
-        )
+    if rank == 0:
+        if filtered_keys:
+            # Summarise by prefix rather than listing every individual key.
+            prefix_counts: dict[str, int] = {}
+            for key in filtered_keys:
+                matched = next(
+                    (p for p in key_prefix_filter if key.startswith(p)), key.split(".")[0] + "."  # type: ignore[union-attr]
+                )
+                prefix_counts[matched] = prefix_counts.get(matched, 0) + 1
+            summary = ", ".join(
+                f'"{p}" ({n} key{"s" if n != 1 else ""})' for p, n in sorted(prefix_counts.items())
+            )
+            logger.info(
+                f"key_prefix_filter is set {list(key_prefix_filter)}; "  # type: ignore[arg-type]
+                f"intentionally skipped checkpoint keys outside allowed prefixes: {summary}"
+            )
+
+        if unused_keys:
+            logger.warning(
+                f"Keys from checkpoint (adapted to FMS) "
+                f"not copied into model: {unused_keys}"
+            )
 
 
 def _copy_if_present(parameter, tensor_value):

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -502,6 +502,7 @@ def load_state_dict_into_model(
     checkpoint_sharding: Optional[str] = None,
     initial_device: torch.device = torch.device("cpu"),
     rank: int = 0,
+    key_prefix_filter: Optional[tuple] = None,
 ) -> None:
     """
     This function loads state_dict into model in the most efficient way possible,
@@ -547,6 +548,15 @@ def load_state_dict_into_model(
         for key in sd_keys:
             if key in used_keys:
                 continue
+
+            # Skip checkpoint keys that don't match any allowed prefix (HF-side names).
+            # Filtered tensors are never read from disk when using LazySafetensorsDict.
+            if key_prefix_filter is not None and not any(
+                key.startswith(p) for p in key_prefix_filter
+            ):
+                unused_keys.add(key)
+                continue
+
             used_keys.add(key)
 
             partial_sd = {key: state_dict[key]}

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -535,6 +535,8 @@ def load_state_dict_into_model(
     adapter_kwargs: dict[str, Any] = {}
     if hasattr(model, "config"):
         adapter_kwargs["model_config"] = model.config
+    if hasattr(model, "_vision_only"):
+        adapter_kwargs["vision_only"] = model._vision_only
 
     # 2. Decide if model needs sharding and how (for now only TP)
     needs_tp_sharding = checkpoint_sharding != "tp" and distributed_strategy == "tp"
@@ -724,9 +726,12 @@ def _load_partial_state_dict(
 
 # Expand QKV and Dense weights to match head_dim override
 def _weight_expansion_for_mismatched_head_dim(
-    input_sd: Mapping[str, Any], model_config
+    input_sd: Mapping[str, Any], model_config=None, **kwargs
 ) -> Mapping[str, Any]:
     new_sd = dict(input_sd)
+
+    if model_config is None:
+        return new_sd
 
     # For multi model this expansion will be applicable only to the language_model
     if hasattr(model_config, "text_config") and isinstance(

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -591,19 +591,9 @@ def load_state_dict_into_model(
 
     if rank == 0:
         if filtered_keys:
-            # Summarise by prefix rather than listing every individual key.
-            prefix_counts: dict[str, int] = {}
-            for key in filtered_keys:
-                matched = next(
-                    (p for p in key_prefix_filter if key.startswith(p)), key.split(".")[0] + "."  # type: ignore[union-attr]
-                )
-                prefix_counts[matched] = prefix_counts.get(matched, 0) + 1
-            summary = ", ".join(
-                f'"{p}" ({n} key{"s" if n != 1 else ""})' for p, n in sorted(prefix_counts.items())
-            )
             logger.info(
-                f"key_prefix_filter is set {list(key_prefix_filter)}; "  # type: ignore[arg-type]
-                f"intentionally skipped checkpoint keys outside allowed prefixes: {summary}"
+                f"key_prefix_filter {list(key_prefix_filter)} is set; "  # type: ignore[arg-type]
+                f"skipped {len(filtered_keys)} checkpoint keys outside allowed prefixes"
             )
 
         if unused_keys:

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -552,8 +552,7 @@ def load_state_dict_into_model(
     # spurious unused_keys warnings.
     if key_prefix_filter is not None:
         filtered_keys = {
-            k for k in sd_keys
-            if not any(k.startswith(p) for p in key_prefix_filter)
+            k for k in sd_keys if not any(k.startswith(p) for p in key_prefix_filter)
         }
     else:
         filtered_keys = set()

--- a/fms/utils/serialization.py
+++ b/fms/utils/serialization.py
@@ -544,20 +544,23 @@ def load_state_dict_into_model(
     # 3. Iterate over the weights and load them into the model
     used_keys = set()
     unused_keys = set()
-    filtered_keys = set()  # keys intentionally skipped by key_prefix_filter
     sd_keys = set(state_dict.keys())
+
+    # Pre-compute filtered keys so they are excluded from neighbor discovery.
+    # Without this, a key with no numeric segment (e.g. the embedding key) would
+    # pull filtered LLM keys in as "neighbors", bypassing the filter and producing
+    # spurious unused_keys warnings.
+    if key_prefix_filter is not None:
+        filtered_keys = {
+            k for k in sd_keys
+            if not any(k.startswith(p) for p in key_prefix_filter)
+        }
+    else:
+        filtered_keys = set()
 
     with torch.no_grad():
         for key in sd_keys:
-            if key in used_keys:
-                continue
-
-            # Skip checkpoint keys that don't match any allowed prefix (HF-side names).
-            # Filtered tensors are never read from disk when using LazySafetensorsDict.
-            if key_prefix_filter is not None and not any(
-                key.startswith(p) for p in key_prefix_filter
-            ):
-                filtered_keys.add(key)
+            if key in used_keys or key in filtered_keys:
                 continue
 
             used_keys.add(key)
@@ -565,7 +568,8 @@ def load_state_dict_into_model(
             partial_sd = {key: state_dict[key]}
             # Find neighbors to the key. If the adapter requires a neighbor and
             # this function doesn't find it, it will crash.
-            remaining_keys = sd_keys.difference(used_keys)
+            # Exclude filtered keys so they are never pulled in as neighbors.
+            remaining_keys = sd_keys.difference(used_keys).difference(filtered_keys)
             neighbors = _find_key_neighbors(key, remaining_keys)
             for neighbor in neighbors:
                 partial_sd[neighbor] = state_dict[neighbor]

--- a/tests/models/test_llava_next.py
+++ b/tests/models/test_llava_next.py
@@ -149,3 +149,114 @@ class TestLlavaNext(
         pytest.skip(
             "llava_next uses nested configs for vision and text model, which get flattened with config.as_dict()"
         )
+
+
+class TestLlavaNextVisionOnly:
+    """Tests for LlavaNext vision_only=True mode."""
+
+    @pytest.fixture
+    def config(self):
+        _text_config = GraniteConfig(
+            src_vocab_size=384,
+            emb_dim=16,
+            norm_eps=1e-5,
+            nheads=8,
+            head_dim=2,
+            kvheads=8,
+            nlayers=2,
+            hidden_grow_factor=4,
+            max_expected_seq_len=4096,
+            pad_id=0,
+            p_dropout=0.0,
+            tie_heads=True,
+            embedding_multiplier=12.0,
+            logits_scaling=8.0,
+            residual_multiplier=0.22,
+            attention_multiplier=0.015625,
+            fused_weights=True,
+        )
+        _vision_config = SiglipVisionConfig(
+            hidden_size=16,
+            image_size=384,
+            intermediate_size=64,
+            nheads=8,
+            nlayers=8,
+            patch_size=14,
+            fused_weights=True,
+        )
+        return LlavaNextConfig(
+            vision_config=_vision_config,
+            text_config=_text_config,
+            image_token_index=383,
+            projector_hidden_act="gelu",
+            vision_feature_select_strategy="full",
+            vision_feature_layer=[-4, -2],
+            multimodal_projector_bias=True,
+            fused_weights=True,
+        )
+
+    def test_vision_only_skips_language_model(self, config):
+        model = LlavaNext(config, vision_only=True)
+        assert model._vision_only is True
+        assert not hasattr(model, "language_model")
+        assert hasattr(model, "text_embedding")
+        assert hasattr(model, "vision_tower")
+        assert hasattr(model, "multi_modal_projector")
+
+    def test_vision_only_false_has_language_model(self, config):
+        model = LlavaNext(config, vision_only=False)
+        assert model._vision_only is False
+        assert hasattr(model, "language_model")
+        assert not hasattr(model, "text_embedding")
+
+    def test_vision_only_text_embedding_shape(self, config):
+        model = LlavaNext(config, vision_only=True)
+        assert model.text_embedding.num_embeddings == config.text_config.src_vocab_size
+        assert model.text_embedding.embedding_dim == config.text_config.emb_dim
+
+    def test_vision_only_get_text_embeddings(self, config):
+        model = LlavaNext(config, vision_only=True)
+        input_ids = torch.arange(10).unsqueeze(0)
+        embeds = model._get_text_embeddings(input_ids)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_prepare_inputs_no_image(self, config):
+        """With no pixel_values, prepare_inputs returns text embeddings only."""
+        model = LlavaNext(config, vision_only=True)
+        model.eval()
+        input_ids = torch.arange(10).unsqueeze(0)
+        kwargs = {"use_cache": False, "attn_name": "sdpa_causal"}
+        embeds, _ = model.prepare_inputs_for_generation(0, input_ids, kwargs)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_prepare_inputs_missing_use_cache(self, config):
+        """use_cache absent from kwargs must not raise a KeyError."""
+        model = LlavaNext(config, vision_only=True)
+        model.eval()
+        input_ids = torch.arange(10).unsqueeze(0)
+        kwargs = {"attn_name": "sdpa_causal"}
+        embeds, _ = model.prepare_inputs_for_generation(0, input_ids, kwargs)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_state_dict_has_no_language_model(self, config):
+        model = LlavaNext(config, vision_only=True)
+        keys = list(model.state_dict().keys())
+        assert not any(k.startswith("language_model.") for k in keys)
+        assert any(k.startswith("vision_tower.") for k in keys)
+        assert any(k.startswith("multi_modal_projector.") for k in keys)
+        assert any(k.startswith("text_embedding.") for k in keys)
+
+    def test_vision_only_reset_parameters_does_not_access_language_model(self, config):
+        """reset_parameters must not raise AttributeError about language_model being absent."""
+        model = LlavaNext(config, vision_only=True)
+        # Patch vision_tower.reset_parameters to avoid unrelated recursion in siglip
+        import unittest.mock as mock
+        with mock.patch.object(model.vision_tower, "reset_parameters"):
+            model.reset_parameters()  # should not raise AttributeError
+
+    def test_vision_only_hf_prefixes_class_attribute(self):
+        assert hasattr(LlavaNext, "VISION_ONLY_HF_PREFIXES")
+        prefixes = LlavaNext.VISION_ONLY_HF_PREFIXES
+        assert any("vision_tower" in p for p in prefixes)
+        assert any("multi_modal_projector" in p for p in prefixes)
+        assert any("embed_tokens" in p for p in prefixes)

--- a/tests/models/test_llava_next.py
+++ b/tests/models/test_llava_next.py
@@ -251,6 +251,7 @@ class TestLlavaNextVisionOnly:
         model = LlavaNext(config, vision_only=True)
         # Patch vision_tower.reset_parameters to avoid unrelated recursion in siglip
         import unittest.mock as mock
+
         with mock.patch.object(model.vision_tower, "reset_parameters"):
             model.reset_parameters()  # should not raise AttributeError
 

--- a/tests/models/test_ministral3.py
+++ b/tests/models/test_ministral3.py
@@ -231,11 +231,13 @@ class TestMinistral3VisionOnly:
         model = Ministral3(config, vision_only=True)
         # Patch vision_tower.reset_parameters to avoid unrelated recursion in pixtral
         import unittest.mock as mock
+
         with mock.patch.object(model.vision_tower, "reset_parameters"):
             model.reset_parameters()  # should not raise AttributeError
 
     def test_vision_only_inherits_get_text_embeddings_from_mistral3(self, config):
         """Ministral3 uses Mistral3._get_text_embeddings — verify the MRO dispatches correctly."""
         from fms.models.mistral3 import Mistral3
+
         model = Ministral3(config, vision_only=True)
         assert type(model)._get_text_embeddings is Mistral3._get_text_embeddings

--- a/tests/models/test_ministral3.py
+++ b/tests/models/test_ministral3.py
@@ -126,3 +126,116 @@ class TestMinistral3(
         # modify feature layer to the new value expected and check equivalence
         config.vision_feature_layer = config.vision_feature_layer - 1
         assert model.get_config().as_dict() == config.as_dict()
+
+
+class TestMinistral3VisionOnly:
+    """Tests for Ministral3 vision_only=True mode."""
+
+    @pytest.fixture
+    def config(self):
+        _text_config = Ministral3TextConfig(
+            src_vocab_size=384,
+            nheads=8,
+            nlayers=2,
+            hidden_grow_factor=3.5,
+            multiple_of=2,
+            tie_heads=False,
+            p_dropout=0.0,
+            activation_fn="silu",
+            emb_dim=16,
+            head_dim=64,
+            max_expected_seq_len=1024,
+            kvheads=2,
+            norm_eps=1e-05,
+            sliding_window=None,
+            rope_parameters={
+                "rope_type": "yarn",
+                "rope_theta": 1000.0,
+                "beta_fast": 32.0,
+                "beta_slow": 1.0,
+                "factor": 1.0,
+                "original_max_position_embeddings": 512,
+                "mscale": 1.0,
+                "mscale_all_dim": 1.0,
+                "llama_4_scaling_beta": 0.1,
+            },
+            fused_weights=True,
+            pad_id=0,
+        )
+        _vision_config = PixtralVisionConfig(
+            hidden_size=16,
+            intermediate_size=64,
+            nlayers=2,
+            nheads=8,
+            nchannels=3,
+            image_size=280,
+            patch_size=14,
+            hidden_act="silu",
+            layer_norm_eps=1e-5,
+            rope_theta=1000.0,
+            attention_dropout=0.0,
+            fused_weights=True,
+        )
+        return Ministral3Config(
+            vision_config=_vision_config,
+            text_config=_text_config,
+            spatial_merge_size=2,
+            image_token_index=10,
+            vision_feature_layer=-1,
+        )
+
+    def test_vision_only_skips_language_model(self, config):
+        model = Ministral3(config, vision_only=True)
+        assert model._vision_only is True
+        assert not hasattr(model, "language_model")
+        assert hasattr(model, "text_embedding")
+        assert hasattr(model, "vision_tower")
+        assert hasattr(model, "multi_modal_projector")
+
+    def test_vision_only_false_has_language_model(self, config):
+        model = Ministral3(config, vision_only=False)
+        assert model._vision_only is False
+        assert hasattr(model, "language_model")
+        assert not hasattr(model, "text_embedding")
+
+    def test_vision_only_text_embedding_shape(self, config):
+        model = Ministral3(config, vision_only=True)
+        assert model.text_embedding.num_embeddings == config.text_config.src_vocab_size
+        assert model.text_embedding.embedding_dim == config.text_config.emb_dim
+
+    def test_vision_only_get_text_embeddings(self, config):
+        model = Ministral3(config, vision_only=True)
+        input_ids = torch.arange(10).unsqueeze(0)
+        embeds = model._get_text_embeddings(input_ids, None)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_prepare_inputs_for_generation_no_image(self, config):
+        """With no pixel_values, prepare_inputs returns text embeddings only."""
+        model = Ministral3(config, vision_only=True)
+        model.eval()
+        input_ids = torch.arange(10).unsqueeze(0)
+        kwargs = {"attn_name": "sdpa_causal"}
+        embeds, _ = model.prepare_inputs_for_generation(0, input_ids, kwargs)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_state_dict_has_no_language_model(self, config):
+        model = Ministral3(config, vision_only=True)
+        keys = list(model.state_dict().keys())
+        assert not any(k.startswith("language_model.") for k in keys)
+        assert any(k.startswith("vision_tower.") for k in keys)
+        assert any(k.startswith("multi_modal_projector.") for k in keys)
+        assert any(k.startswith("text_embedding.") for k in keys)
+
+    def test_vision_only_reset_parameters_does_not_access_language_model(self, config):
+        """reset_parameters must not raise AttributeError about language_model being absent."""
+        model = Ministral3(config, vision_only=True)
+        # Patch vision_tower.reset_parameters to avoid unrelated recursion in pixtral
+        import unittest.mock as mock
+        with mock.patch.object(model.vision_tower, "reset_parameters"):
+            model.reset_parameters()  # should not raise AttributeError
+
+    def test_vision_only_inherits_get_text_embeddings_from_mistral3(self, config):
+        """Ministral3 uses Mistral3._get_text_embeddings — verify the MRO dispatches correctly."""
+        from fms.models.mistral3 import Mistral3
+        model = Ministral3(config, vision_only=True)
+        assert type(model)._get_text_embeddings is Mistral3._get_text_embeddings

--- a/tests/models/test_mistral3.py
+++ b/tests/models/test_mistral3.py
@@ -111,3 +111,102 @@ class TestMistral3(
         # modify feature layer to the new value expected and check equivalence
         config.vision_feature_layer = config.vision_feature_layer - 1
         assert model.get_config().as_dict() == config.as_dict()
+
+
+class TestMistral3VisionOnly:
+    """Tests for Mistral3 vision_only=True mode."""
+
+    @pytest.fixture
+    def config(self):
+        from fms.models.mistral import MistralConfig
+
+        _text_config = MistralConfig(
+            src_vocab_size=384,
+            nheads=8,
+            nlayers=2,
+            hidden_grow_factor=3.5,
+            multiple_of=2,
+            tie_heads=False,
+            p_dropout=0.0,
+            activation_fn="swish",
+            emb_dim=16,
+            head_dim=4096 // 32,
+            max_expected_seq_len=4096,
+            kvheads=2,
+            norm_eps=1e-05,
+            sliding_window=4000,
+            rope_base=100_0000.0,
+            fused_weights=True,
+            pad_id=0,
+        )
+        _vision_config = PixtralVisionConfig(
+            hidden_size=16,
+            intermediate_size=64,
+            nlayers=8,
+            nheads=8,
+            nchannels=3,
+            image_size=280,
+            patch_size=14,
+            hidden_act="silu",
+            layer_norm_eps=1e-5,
+            rope_theta=10000.0,
+            attention_dropout=0.0,
+            fused_weights=True,
+        )
+        return Mistral3Config(
+            vision_config=_vision_config,
+            text_config=_text_config,
+            spatial_merge_size=2,
+            image_token_index=10,
+            vision_feature_layer=-1,
+        )
+
+    def test_vision_only_skips_language_model(self, config):
+        model = Mistral3(config, vision_only=True)
+        assert model._vision_only is True
+        assert not hasattr(model, "language_model")
+        assert hasattr(model, "text_embedding")
+        assert hasattr(model, "vision_tower")
+        assert hasattr(model, "multi_modal_projector")
+
+    def test_vision_only_false_has_language_model(self, config):
+        model = Mistral3(config, vision_only=False)
+        assert model._vision_only is False
+        assert hasattr(model, "language_model")
+        assert not hasattr(model, "text_embedding")
+
+    def test_vision_only_text_embedding_shape(self, config):
+        model = Mistral3(config, vision_only=True)
+        assert model.text_embedding.num_embeddings == config.text_config.src_vocab_size
+        assert model.text_embedding.embedding_dim == config.text_config.emb_dim
+
+    def test_vision_only_get_text_embeddings(self, config):
+        model = Mistral3(config, vision_only=True)
+        input_ids = torch.arange(10).unsqueeze(0)
+        embeds = model._get_text_embeddings(input_ids, None)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_prepare_inputs_for_generation_no_image(self, config):
+        """With no pixel_values, prepare_inputs returns text embeddings only."""
+        model = Mistral3(config, vision_only=True)
+        model.eval()
+        input_ids = torch.arange(10).unsqueeze(0)
+        kwargs = {"attn_name": "sdpa_causal"}
+        embeds, _ = model.prepare_inputs_for_generation(0, input_ids, kwargs)
+        assert embeds.shape == (1, 10, config.text_config.emb_dim)
+
+    def test_vision_only_state_dict_has_no_language_model(self, config):
+        model = Mistral3(config, vision_only=True)
+        keys = list(model.state_dict().keys())
+        assert not any(k.startswith("language_model.") for k in keys)
+        assert any(k.startswith("vision_tower.") for k in keys)
+        assert any(k.startswith("multi_modal_projector.") for k in keys)
+        assert any(k.startswith("text_embedding.") for k in keys)
+
+    def test_vision_only_reset_parameters_does_not_access_language_model(self, config):
+        """reset_parameters must not raise AttributeError about language_model being absent."""
+        model = Mistral3(config, vision_only=True)
+        # Patch vision_tower.reset_parameters to avoid unrelated recursion in pixtral
+        import unittest.mock as mock
+        with mock.patch.object(model.vision_tower, "reset_parameters"):
+            model.reset_parameters()  # should not raise AttributeError

--- a/tests/models/test_mistral3.py
+++ b/tests/models/test_mistral3.py
@@ -208,5 +208,6 @@ class TestMistral3VisionOnly:
         model = Mistral3(config, vision_only=True)
         # Patch vision_tower.reset_parameters to avoid unrelated recursion in pixtral
         import unittest.mock as mock
+
         with mock.patch.object(model.vision_tower, "reset_parameters"):
             model.reset_parameters()  # should not raise AttributeError

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -259,7 +259,9 @@ def test_get_model_vision_only_prefix_filter_applied(tmp_path):
     # can assert which were loaded without relying on random-init values.
     with torch.no_grad():
         for name, p in full_model.named_parameters():
-            if name.startswith("vision_tower.") or name.startswith("multi_modal_projector."):
+            if name.startswith("vision_tower.") or name.startswith(
+                "multi_modal_projector."
+            ):
                 p.fill_(1.0)
             elif name.startswith("language_model."):
                 p.fill_(2.0)
@@ -282,5 +284,7 @@ def test_get_model_vision_only_prefix_filter_applied(tmp_path):
 
     # Vision tower and projector params should be 1.0 (loaded from checkpoint)
     for name, p in vision_model.named_parameters():
-        if name.startswith("vision_tower.") or name.startswith("multi_modal_projector."):
+        if name.startswith("vision_tower.") or name.startswith(
+            "multi_modal_projector."
+        ):
             assert p.eq(1.0).all(), f"{name} was not loaded from checkpoint"

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -167,3 +167,120 @@ def test_guess_numlayers():
     model = models._get_model_instance("llama", "micro")
     sd = model.state_dict()
     assert models._guess_num_layers(sd) == 5
+
+
+def _make_ministral3_small():
+    """Return a tiny Ministral3Config suitable for unit tests (no weights needed)."""
+    from fms.models.ministral3 import Ministral3Config, Ministral3TextConfig
+    from fms.models.pixtral_vision import PixtralVisionConfig
+
+    text_cfg = Ministral3TextConfig(
+        src_vocab_size=384,
+        nheads=8,
+        nlayers=2,
+        hidden_grow_factor=3.5,
+        multiple_of=2,
+        emb_dim=16,
+        head_dim=64,
+        max_expected_seq_len=1024,
+        kvheads=2,
+        fused_weights=True,
+        pad_id=0,
+        rope_parameters={
+            "rope_type": "yarn",
+            "rope_theta": 1000.0,
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "factor": 1.0,
+            "original_max_position_embeddings": 512,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "llama_4_scaling_beta": 0.1,
+        },
+    )
+    vision_cfg = PixtralVisionConfig(
+        hidden_size=16,
+        intermediate_size=64,
+        nlayers=2,
+        nheads=8,
+        nchannels=3,
+        image_size=280,
+        patch_size=14,
+        fused_weights=True,
+    )
+    return Ministral3Config(
+        text_config=text_cfg,
+        vision_config=vision_cfg,
+        spatial_merge_size=2,
+        image_token_index=10,
+        vision_feature_layer=-1,
+    )
+
+
+def test_get_model_vision_only_flag_passed_to_model():
+    """vision_only=True is forwarded through _get_model_instance to the constructor."""
+    from fms.models.llava_next import LlavaNext
+
+    # llava_next has no rope-params config issue and its factory accepts **kwargs cleanly
+    model = models._get_model_instance(
+        "llava_next",
+        "granite_vision_3_2_2b",
+        extra_args={"vision_only": True},
+    )
+    assert isinstance(model, LlavaNext)
+    assert model._vision_only is True
+    assert hasattr(model, "text_embedding")
+    assert not hasattr(model, "language_model")
+
+
+def test_get_model_vision_only_default_false():
+    """vision_only defaults to False — language_model is present without the flag."""
+    from fms.models.llava_next import LlavaNext
+
+    model = models._get_model_instance(
+        "llava_next",
+        "granite_vision_3_2_2b",
+        extra_args={"vision_only": False},
+    )
+    assert isinstance(model, LlavaNext)
+    assert model._vision_only is False
+    assert hasattr(model, "language_model")
+    assert not hasattr(model, "text_embedding")
+
+
+def test_get_model_vision_only_prefix_filter_applied(tmp_path):
+    """get_model passes key_prefix_filter when vision_only=True, skipping LLM keys."""
+    from safetensors.torch import save_file
+    from fms.models.llava_next import LlavaNext
+
+    full_model = models._get_model_instance("llava_next", "granite_vision_3_2_2b")
+
+    # Stamp vision components with 1.0 and language components with 2.0 so we
+    # can assert which were loaded without relying on random-init values.
+    with torch.no_grad():
+        for name, p in full_model.named_parameters():
+            if name.startswith("vision_tower.") or name.startswith("multi_modal_projector."):
+                p.fill_(1.0)
+            elif name.startswith("language_model."):
+                p.fill_(2.0)
+
+    save_file(
+        {k: v.contiguous() for k, v in full_model.state_dict().items()},
+        tmp_path / "model.safetensors",
+    )
+
+    vision_model = models.get_model(
+        "llava_next",
+        "granite_vision_3_2_2b",
+        model_path=str(tmp_path),
+        vision_only=True,
+    )
+    assert isinstance(vision_model, LlavaNext)
+    assert vision_model._vision_only is True
+    assert hasattr(vision_model, "text_embedding")
+    assert not hasattr(vision_model, "language_model")
+
+    # Vision tower and projector params should be 1.0 (loaded from checkpoint)
+    for name, p in vision_model.named_parameters():
+        if name.startswith("vision_tower.") or name.startswith("multi_modal_projector."):
+            assert p.eq(1.0).all(), f"{name} was not loaded from checkpoint"

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -165,7 +165,8 @@ def test_load_state_dict_into_model_key_prefix_filter():
     # vision layer loaded, language layer still zeros (not loaded)
     torch.testing.assert_close(model.vision_layers[0].weight, vision_weight)
     torch.testing.assert_close(
-        model.language_layers[0].weight, torch.zeros(4, 4),
+        model.language_layers[0].weight,
+        torch.zeros(4, 4),
         msg="language weights should NOT have been loaded",
     )
 

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -120,3 +120,90 @@ def test_load_state_dict():
                 rank=0,
                 world_size=4,
             )
+
+
+def test_load_state_dict_into_model_key_prefix_filter():
+    """key_prefix_filter skips non-matching keys and loads matching ones.
+
+    Keys must have a numeric layer index so _find_key_neighbors groups them
+    independently (one key per layer) rather than treating all non-layered keys
+    as a single neighbor group.
+    """
+    import torch.nn as nn
+
+    class _Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(4, 4))
+
+    class _TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.vision_layers = nn.ModuleList([_Layer()])
+            self.language_layers = nn.ModuleList([_Layer()])
+
+    arch = "_test_prefix_filter"
+    serialization.register_adapter_step(arch, "noop", lambda sd, **kw: sd)
+    serialization.register_adapter(arch, "fms", ["noop"])
+
+    model = _TinyModel()
+    vision_weight = torch.ones(4, 4)
+    language_weight = torch.full((4, 4), 2.0)
+    state_dict = {
+        "vision_layers.0.weight": vision_weight,
+        "language_layers.0.weight": language_weight,
+    }
+
+    serialization.load_state_dict_into_model(
+        model=model,
+        state_dict=dict(state_dict),
+        architecture=arch,
+        source="fms",
+        key_prefix_filter=("vision_layers.",),
+    )
+
+    # vision layer loaded, language layer still zeros (not loaded)
+    torch.testing.assert_close(model.vision_layers[0].weight, vision_weight)
+    torch.testing.assert_close(
+        model.language_layers[0].weight, torch.zeros(4, 4),
+        msg="language weights should NOT have been loaded",
+    )
+
+
+def test_load_state_dict_into_model_no_filter_loads_all():
+    """Without key_prefix_filter all keys are loaded as normal."""
+    import torch.nn as nn
+
+    class _Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.zeros(4, 4))
+
+    class _TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.vision_layers = nn.ModuleList([_Layer()])
+            self.language_layers = nn.ModuleList([_Layer()])
+
+    arch = "_test_no_filter"
+    serialization.register_adapter_step(arch, "noop", lambda sd, **kw: sd)
+    serialization.register_adapter(arch, "fms", ["noop"])
+
+    model = _TinyModel()
+    vision_weight = torch.ones(4, 4)
+    language_weight = torch.full((4, 4), 2.0)
+    state_dict = {
+        "vision_layers.0.weight": vision_weight,
+        "language_layers.0.weight": language_weight,
+    }
+
+    serialization.load_state_dict_into_model(
+        model=model,
+        state_dict=dict(state_dict),
+        architecture=arch,
+        source="fms",
+        key_prefix_filter=None,
+    )
+
+    torch.testing.assert_close(model.vision_layers[0].weight, vision_weight)
+    torch.testing.assert_close(model.language_layers[0].weight, language_weight)


### PR DESCRIPTION
### Changes

This PR adds ability to load vision part of the model from a given multimodal model.  This allows ability for sendnn-inference to load the model's different parts differently for efficient processing